### PR TITLE
fix: correct About Us stylesheet path

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -6,7 +6,7 @@
   <title>Below Surface – Marine Adventures</title>
 
   <!-- Link to external main CSS -->
-  <link rel="stylesheet" href="assets/css/main.css" />
+  <link rel="stylesheet" href="../assets/css/main.css" />
 
 </head>
 <body>


### PR DESCRIPTION
## Summary
- fix About Us page to reference shared main CSS using relative path

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f70416efc83208f50a2bc57d47725