### PR TITLE
Ensure single-column layout for day trip cards

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -166,6 +166,14 @@ html, body {
   align-items: center !important;
 }
 
+/* Day Trips: force single column layout on all screens */
+.daytrips .services__grid {
+  grid-template-columns: 1fr !important;
+  max-width: 400px !important;
+  gap: 1.5rem !important;
+  justify-content: center !important;
+}
+
 /* Ensure cards are centered within their grid area */
 .services__card,
 .daytrips .services__card {
@@ -176,8 +184,7 @@ html, body {
 
 /* For smaller screens, ensure single column is centered */
 @media (max-width: 768px) {
-  .services__grid,
-  .daytrips .services__grid {
+  .services__grid {
     grid-template-columns: 1fr !important;
     max-width: 400px !important;
     gap: 1.5rem !important;


### PR DESCRIPTION
## Summary
- Force day-trip service grid to one column at all viewport widths
- Simplify responsive CSS so other pages still adapt on small screens

## Testing
- `npx prettier --check assets/css/main.css day-trips/index.html` *(fails: Code style issues found)*
- `npx htmlhint day-trips/index.html`


------
https://chatgpt.com/codex/tasks/task_e_689f7740f11c8320b6591b5ae4c974c2