### PR TITLE
Align day trip and expedition card styles

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -607,8 +607,9 @@ html, body {
   }
 }
 
-/* ===== DAY TRIPS SECTION ===== */
-.daytrips.section {
+/* ===== DAY TRIPS & EXPEDITIONS SECTION ===== */
+.daytrips.section,
+.expeditions.section {
   position: relative;
   width: 100vw;
   left: 50%;
@@ -619,14 +620,16 @@ html, body {
   isolation: isolate;
 }
 
-.daytrips .services__heading {
+.daytrips .services__heading,
+.expeditions .services__heading {
   text-align: center;
   font: 700 clamp(2rem,4vw,3rem)/1.2 inherit;
   color: var(--highlight);
   margin-bottom: clamp(1rem,2vh,1.5rem);
 }
 
-.daytrips .services__desc {
+.daytrips .services__desc,
+.expeditions .services__desc {
   max-width: 600px;
   margin: 0 auto clamp(3rem,6vh,4rem);
   text-align: center;
@@ -635,7 +638,8 @@ html, body {
   line-height: 1.4;
 }
 
-.daytrips .services__grid {
+.daytrips .services__grid,
+.expeditions .services__grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px,1fr));
   gap: clamp(1.5rem,4vw,2.5rem);
@@ -650,7 +654,8 @@ html, body {
   75% { transform: translate(-10px,-10px); }
 }
 
-.daytrips .services__card {
+.daytrips .services__card,
+.expeditions .services__card {
   --ft: 10s;
   width: 100%;
   max-width: 360px;
@@ -663,7 +668,8 @@ html, body {
   animation-delay: calc(var(--i,0) * -1.2s);
 }
 
-.daytrips .services__img {
+.daytrips .services__img,
+.expeditions .services__img {
   width: 100%;
   aspect-ratio: 16/9;
   background-size: cover;
@@ -673,7 +679,8 @@ html, body {
   transition: transform .3s ease;
 }
 
-.daytrips .services__overlay {
+.daytrips .services__overlay,
+.expeditions .services__overlay {
   padding: clamp(1.5rem,2.4vw,2.4rem) clamp(1.5rem,2.4vw,2.6rem);
   background: rgba(33,38,45,0.7);
   border-bottom-left-radius: 32px;
@@ -685,14 +692,16 @@ html, body {
   transition: background .3s ease, box-shadow .3s ease, filter .3s ease;
 }
 
-.daytrips .services__title {
+.daytrips .services__title,
+.expeditions .services__title {
   margin: 0 0 .75rem;
   font-size: clamp(1.4rem,2.5vw,1.8rem);
   font-weight: 700;
   color: #fff;
 }
 
-.daytrips .services__text {
+.daytrips .services__text,
+.expeditions .services__text {
   margin: 0 0 1.5rem;
   font-size: clamp(.95rem,1.2vw,1.1rem);
   line-height: 1.5;
@@ -700,7 +709,8 @@ html, body {
   max-height: 3.3em;
 }
 
-.daytrips .services__btn {
+.daytrips .services__btn,
+.expeditions .services__btn {
   align-self: flex-start;
   background: var(--highlight);
   color: var(--ink);
@@ -712,17 +722,20 @@ html, body {
   transition: background .3s ease, transform .3s ease;
 }
 
-.daytrips .services__btn:hover {
+.daytrips .services__btn:hover,
+.expeditions .services__btn:hover {
   background: #fff;
   transform: translateY(-2px);
 }
 
-.daytrips .services__card:hover {
+.daytrips .services__card:hover,
+.expeditions .services__card:hover {
   transform: scale(1.05);
   box-shadow: 0 20px 60px rgba(0,0,0,0.7);
 }
 
-.daytrips .services__card:hover .services__overlay {
+.daytrips .services__card:hover .services__overlay,
+.expeditions .services__card:hover .services__overlay {
   background: rgba(33,38,45,0.85);
   box-shadow: inset 0 0 20px rgba(255,255,255,0.2);
   filter: brightness(1.05) contrast(1.05);
@@ -735,7 +748,8 @@ html, body {
     grid-template-columns: 1fr;
   }
 
-  .daytrips .services__heading {
+  .daytrips .services__heading,
+  .expeditions .services__heading {
     font-size: clamp(1.8rem,8vw,2.4rem);
   }
 }
@@ -918,7 +932,8 @@ body.scrolled .elementor-location-header {
   .review-card,
   .contact__panel,
   .whatsapp-button,
-  .daytrips .services__card {
+  .daytrips .services__card,
+  .expeditions .services__card {
     animation: none !important;
   }
   
@@ -932,7 +947,8 @@ body.scrolled .elementor-location-header {
 /* Focus indicators */
 .review__nav:focus,
 .contact__btn:focus,
-.daytrips .services__btn:focus {
+.daytrips .services__btn:focus,
+.expeditions .services__btn:focus {
   outline: 2px solid var(--highlight);
   outline-offset: 3px;
 }

--- a/expeditions/index.html
+++ b/expeditions/index.html
@@ -9,7 +9,7 @@
 </head>
 <body>
 
-<section class="daytrips section" id="daytrips" aria-label="Day Trips">
+<section class="expeditions section" id="expeditions" aria-label="Expeditions">
   <h2 class="services__heading">Expeditions</h2>
   <p class="services__desc" style="max-width:600px; margin:0 auto 3rem; text-align:center; font-size:clamp(1.1rem,2vw,1.4rem); color:var(--text-light);">
    Our expeditions are fully customizable to cover all your needs


### PR DESCRIPTION
## Summary
- Share responsive layout and card styling between day trips and expeditions
- Add expeditions class to reduced-motion and focus styles
- Use correct section metadata for the expeditions page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f7bf556bc83208040799af1b14581