### PR TITLE
Show current page title near hamburger menu

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -77,6 +77,15 @@
   }
   .ham:hover, .ham:focus, .ham:focus-visible{ background:transparent; box-shadow:none; outline:none; }
   .ham__icon{ width:24px; height:18px; position:relative; }
+  .ham__text{
+    position:absolute; top:50%; left:100%; margin-left:8px;
+    transform:translateY(-50%);
+    color:var(--accent); font-weight:700; white-space:nowrap;
+    opacity:0; transition:opacity .2s ease;
+    pointer-events:none;
+  }
+  .ham:hover .ham__text,
+  .ham[aria-expanded="true"] .ham__text{ opacity:1; }
   .ham__bar{
     position:absolute; left:0; right:0; height:2px; background:var(--accent);
     border-radius:2px; transform-origin:50% 50%;
@@ -167,6 +176,7 @@
     <span class="ham__bar ham__bar--2"></span>
     <span class="ham__bar ham__bar--3"></span>
   </span>
+  <span class="ham__text"></span>
 </button>
 
 <!-- Fullscreen Menu -->
@@ -215,13 +225,20 @@
   const btn = document.getElementById('ham');
   const menu = document.getElementById('menu');
   const links = menu.querySelectorAll('.menu__link');
+  const hamText = btn.querySelector('.ham__text');
   let lastFocus = null;
 
   // Ensure ONLY one active link
   const norm = (u)=>{ try{ const x=new URL(u, location.origin); return (x.origin+x.pathname+x.search).replace(/\/+$/,''); } catch(e){ return u; } };
   const here = norm(location.href);
   links.forEach(l => { l.classList.remove('is-active'); l.removeAttribute('aria-current'); });
-  links.forEach(a => { if (norm(a.href) === here) { a.classList.add('is-active'); a.setAttribute('aria-current','page'); } });
+  links.forEach(a => {
+    if (norm(a.href) === here) {
+      a.classList.add('is-active');
+      a.setAttribute('aria-current','page');
+      if(hamText) hamText.textContent = a.textContent.trim();
+    }
+  });
 
   const lock = (on)=>{ document.documentElement.style.overflow = on ? 'hidden' : ''; };
 

--- a/charter/index.html
+++ b/charter/index.html
@@ -26,6 +26,15 @@
   }
   .ham:hover, .ham:focus, .ham:focus-visible{ background:transparent; box-shadow:none; outline:none; }
   .ham__icon{ width:24px; height:18px; position:relative; }
+  .ham__text{
+    position:absolute; top:50%; left:100%; margin-left:8px;
+    transform:translateY(-50%);
+    color:var(--accent); font-weight:700; white-space:nowrap;
+    opacity:0; transition:opacity .2s ease;
+    pointer-events:none;
+  }
+  .ham:hover .ham__text,
+  .ham[aria-expanded="true"] .ham__text{ opacity:1; }
   .ham__bar{
     position:absolute; left:0; right:0; height:2px; background:var(--accent);
     border-radius:2px; transform-origin:50% 50%;
@@ -117,6 +126,7 @@
     <span class="ham__bar ham__bar--2"></span>
     <span class="ham__bar ham__bar--3"></span>
   </span>
+  <span class="ham__text"></span>
 </button>
 
 <!-- Fullscreen Menu -->
@@ -170,13 +180,20 @@
   const btn = document.getElementById('ham');
   const menu = document.getElementById('menu');
   const links = menu.querySelectorAll('.menu__link');
+  const hamText = btn.querySelector('.ham__text');
   let lastFocus = null;
 
   // Ensure ONLY one active link
   const norm = (u)=>{ try{ const x=new URL(u, location.origin); return (x.origin+x.pathname+x.search).replace(/\/+$/,''); } catch(e){ return u; } };
   const here = norm(location.href);
   links.forEach(l => { l.classList.remove('is-active'); l.removeAttribute('aria-current'); });
-  links.forEach(a => { if (norm(a.href) === here) { a.classList.add('is-active'); a.setAttribute('aria-current','page'); } });
+  links.forEach(a => {
+    if (norm(a.href) === here) {
+      a.classList.add('is-active');
+      a.setAttribute('aria-current','page');
+      if(hamText) hamText.textContent = a.textContent.trim();
+    }
+  });
 
   const lock = (on)=>{ document.documentElement.style.overflow = on ? 'hidden' : ''; };
 

--- a/day-trips/index.html
+++ b/day-trips/index.html
@@ -179,6 +179,15 @@
   }
   .ham:hover, .ham:focus, .ham:focus-visible{ background:transparent; box-shadow:none; outline:none; }
   .ham__icon{ width:24px; height:18px; position:relative; }
+  .ham__text{
+    position:absolute; top:50%; left:100%; margin-left:8px;
+    transform:translateY(-50%);
+    color:var(--accent); font-weight:700; white-space:nowrap;
+    opacity:0; transition:opacity .2s ease;
+    pointer-events:none;
+  }
+  .ham:hover .ham__text,
+  .ham[aria-expanded="true"] .ham__text{ opacity:1; }
   .ham__bar{
     position:absolute; left:0; right:0; height:2px; background:var(--accent);
     border-radius:2px; transform-origin:50% 50%;
@@ -270,6 +279,7 @@
     <span class="ham__bar ham__bar--2"></span>
     <span class="ham__bar ham__bar--3"></span>
   </span>
+  <span class="ham__text"></span>
 </button>
 
 <!-- Fullscreen Menu -->
@@ -316,13 +326,20 @@
   const btn = document.getElementById('ham');
   const menu = document.getElementById('menu');
   const links = menu.querySelectorAll('.menu__link');
+  const hamText = btn.querySelector('.ham__text');
   let lastFocus = null;
 
   // Ensure ONLY one active link
   const norm = (u)=>{ try{ const x=new URL(u, location.origin); return (x.origin+x.pathname+x.search).replace(/\/+$/,''); } catch(e){ return u; } };
   const here = norm(location.href);
   links.forEach(l => { l.classList.remove('is-active'); l.removeAttribute('aria-current'); });
-  links.forEach(a => { if (norm(a.href) === here) { a.classList.add('is-active'); a.setAttribute('aria-current','page'); } });
+  links.forEach(a => {
+    if (norm(a.href) === here) {
+      a.classList.add('is-active');
+      a.setAttribute('aria-current','page');
+      if(hamText) hamText.textContent = a.textContent.trim();
+    }
+  });
 
   const lock = (on)=>{ document.documentElement.style.overflow = on ? 'hidden' : ''; };
 

--- a/expeditions/index.html
+++ b/expeditions/index.html
@@ -150,6 +150,15 @@
   }
   .ham:hover, .ham:focus, .ham:focus-visible{ background:transparent; box-shadow:none; outline:none; }
   .ham__icon{ width:24px; height:18px; position:relative; }
+  .ham__text{
+    position:absolute; top:50%; left:100%; margin-left:8px;
+    transform:translateY(-50%);
+    color:var(--accent); font-weight:700; white-space:nowrap;
+    opacity:0; transition:opacity .2s ease;
+    pointer-events:none;
+  }
+  .ham:hover .ham__text,
+  .ham[aria-expanded="true"] .ham__text{ opacity:1; }
   .ham__bar{
     position:absolute; left:0; right:0; height:2px; background:var(--accent);
     border-radius:2px; transform-origin:50% 50%;
@@ -239,6 +248,7 @@
     <span class="ham__bar ham__bar--2"></span>
     <span class="ham__bar ham__bar--3"></span>
   </span>
+  <span class="ham__text"></span>
 </button>
 
 <nav class="menu" id="menu" aria-hidden="true">
@@ -281,12 +291,19 @@
   const btn = document.getElementById('ham');
   const menu = document.getElementById('menu');
   const links = menu.querySelectorAll('.menu__link');
+  const hamText = btn.querySelector('.ham__text');
   let lastFocus = null;
 
   const norm = (u)=>{ try{ const x=new URL(u, location.origin); return (x.origin+x.pathname+x.search).replace(/\/+$/,''); } catch(e){ return u; } };
   const here = norm(location.href);
   links.forEach(l => { l.classList.remove('is-active'); l.removeAttribute('aria-current'); });
-  links.forEach(a => { if (norm(a.href) === here) { a.classList.add('is-active'); a.setAttribute('aria-current','page'); } });
+  links.forEach(a => {
+    if (norm(a.href) === here) {
+      a.classList.add('is-active');
+      a.setAttribute('aria-current','page');
+      if(hamText) hamText.textContent = a.textContent.trim();
+    }
+  });
 
   const lock = (on)=>{ document.documentElement.style.overflow = on ? 'hidden' : ''; };
 

--- a/index.html
+++ b/index.html
@@ -1948,6 +1948,15 @@ document.addEventListener('scroll',function(){
   }
   .ham:hover, .ham:focus, .ham:focus-visible{ background:transparent; box-shadow:none; outline:none; }
   .ham__icon{ width:24px; height:18px; position:relative; }
+  .ham__text{
+    position:absolute; top:50%; left:100%; margin-left:8px;
+    transform:translateY(-50%);
+    color:var(--accent); font-weight:700; white-space:nowrap;
+    opacity:0; transition:opacity .2s ease;
+    pointer-events:none;
+  }
+  .ham:hover .ham__text,
+  .ham[aria-expanded="true"] .ham__text{ opacity:1; }
   .ham__bar{
     position:absolute; left:0; right:0; height:2px; background:var(--accent);
     border-radius:2px; transform-origin:50% 50%;
@@ -2039,6 +2048,7 @@ document.addEventListener('scroll',function(){
     <span class="ham__bar ham__bar--2"></span>
     <span class="ham__bar ham__bar--3"></span>
   </span>
+  <span class="ham__text"></span>
 </button>
 
 <!-- Fullscreen Menu -->
@@ -2087,13 +2097,20 @@ document.addEventListener('scroll',function(){
   const btn = document.getElementById('ham');
   const menu = document.getElementById('menu');
   const links = menu.querySelectorAll('.menu__link');
+  const hamText = btn.querySelector('.ham__text');
   let lastFocus = null;
 
   // Ensure ONLY one active link
   const norm = (u)=>{ try{ const x=new URL(u, location.origin); return (x.origin+x.pathname+x.search).replace(/\/+$/,''); } catch(e){ return u; } };
   const here = norm(location.href);
   links.forEach(l => { l.classList.remove('is-active'); l.removeAttribute('aria-current'); });
-  links.forEach(a => { if (norm(a.href) === here) { a.classList.add('is-active'); a.setAttribute('aria-current','page'); } });
+  links.forEach(a => {
+    if (norm(a.href) === here) {
+      a.classList.add('is-active');
+      a.setAttribute('aria-current','page');
+      if(hamText) hamText.textContent = a.textContent.trim();
+    }
+  });
 
   const lock = (on)=>{ document.documentElement.style.overflow = on ? 'hidden' : ''; };
 


### PR DESCRIPTION
## Summary
- Display current page title beside hamburger icon
- Highlight active menu link and show page name on hover/open

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f7c4e01088320b18c5c0edaea3ee0