### PR TITLE
Make day trip cards stack vertically on mobile

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -638,7 +638,14 @@ html, body {
   line-height: 1.4;
 }
 
-.daytrips .services__grid,
+.daytrips .services__grid {
+  display: grid;
+  grid-template-columns: 1fr !important;
+  gap: clamp(1.5rem,4vw,2.5rem);
+  justify-content: center;
+  justify-items: center;
+}
+
 .expeditions .services__grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px,1fr));


### PR DESCRIPTION
## Summary
- Ensure Day Trips page displays one card per row for improved mobile scrolling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f7e46a31c8320b20d07760be83ebc