### PR TITLE
Remove gallery edge fade and ensure frames scale above canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -1227,16 +1227,13 @@
       gap: var(--bs-gap);
       height: 100%;
       overflow-x: auto;                   /* enable horizontal scroll */
-      overflow-y: hidden;
+      overflow-y: visible;                /* allow scaling beyond row height */
       -webkit-overflow-scrolling: touch;  /* iOS momentum */
       scroll-behavior: smooth;            /* smooth for button/programmatic scroll */
       border-radius: 24px;
       /* keep page vertical scroll responsive */
       overscroll-behavior-x: contain;     /* prevent horizontal overscroll bouncing page */
       overscroll-behavior-y: auto;        /* allow normal vertical scroll */
-      /* fade edges */
-      -webkit-mask-image: linear-gradient(to right, transparent 0, #000 5%, #000 95%, transparent 100%);
-      mask-image: linear-gradient(to right, transparent 0, #000 5%, #000 95%, transparent 100%);
       /* hide scrollbars */
       scrollbar-width: none;
       -ms-overflow-style: none;
@@ -1256,7 +1253,7 @@
       user-select: none;
       -webkit-user-drag: none;
       position: relative;
-      z-index: 1; /* keep pictures above everything on mobile */
+      z-index: 3; /* ensure images stay above canvas */
     }
 
     .bs-gallery-row img:hover {
@@ -1282,7 +1279,7 @@
       cursor: pointer;
       backdrop-filter: blur(6px);
       transition: transform .2s ease, background .2s ease;
-      z-index: 2;
+      z-index: 4;
       line-height: 1;
     }
     .bs-row-btn:hover { background: rgba(0,0,0,0.85); transform: translateY(-50%) scale(1.06); }


### PR DESCRIPTION
## Summary
- Remove gradient mask to eliminate fading on gallery edges and prevent clipping during hover
- Keep gallery images above canvas and carousel buttons by raising z-index and allowing vertical overflow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f847bc5d0832088dbcbc8ae903366