### PR TITLE
Fix Get to Know Us link to About Us page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1150,7 +1150,7 @@
         Every expedition, day trip, and charter blends responsible exploration with authentic local
         insight—helping guests experience hidden depths while protecting them for future generations.
       </p>
-      <a class="about__btn" href="https://bajabelowsurface.com/?page_id=1397">Read&nbsp;More</a>
+      <a class="about__btn" href="about-us/">Read&nbsp;More</a>
     </article>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- Link "Get to Know Us" section's Read More button to the internal About Us page

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f874d12a48320854157aa822ea0c1