### PR TITLE
Add sticky header logo

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -69,11 +69,25 @@
     --z:99999;
   }
 
+  /* Sticky header with translucent blur */
+  .bs-header{
+    position:fixed; top:0; left:0; width:100%;
+    display:flex; justify-content:center; align-items:center;
+    padding:4px 0;
+    background:rgba(13,24,30,.35);
+    -webkit-backdrop-filter:blur(14px);
+    backdrop-filter:blur(14px);
+    z-index:var(--z);
+  }
+  .bs-logo{ width:48px; height:48px; display:block; margin:0 auto; }
+  .bs-logo img{ width:100%; height:100%; object-fit:contain; display:block; }
+
   /* Hamburger: yellow lines only, no hover bg */
   .ham{
-    position:fixed; top:clamp(10px,2vh,18px); left:clamp(10px,2vw,18px);
+    position:absolute;
+    left:clamp(10px,2vw,18px); top:50%; transform:translateY(-50%);
     width:48px; height:48px; border:0; background:transparent; padding:0; cursor:pointer;
-    display:grid; place-items:center; z-index:var(--z); border-radius:12px;
+    display:grid; place-items:center; border-radius:12px;
   }
   .ham:hover, .ham:focus, .ham:focus-visible{ background:transparent; box-shadow:none; outline:none; }
   .ham__icon{ width:24px; height:18px; position:relative; }
@@ -169,15 +183,20 @@
 
   /* Titles remain centered across all viewport widths */
 </style>
-<!-- Button -->
-<button class="ham" id="ham" aria-label="Open menu" aria-controls="menu" aria-expanded="false">
-  <span class="ham__icon" aria-hidden="true">
-    <span class="ham__bar ham__bar--1"></span>
-    <span class="ham__bar ham__bar--2"></span>
-    <span class="ham__bar ham__bar--3"></span>
-  </span>
-  <span class="ham__text"></span>
-</button>
+<!-- Sticky Header -->
+<header class="bs-header">
+  <button class="ham" id="ham" aria-label="Open menu" aria-controls="menu" aria-expanded="false">
+    <span class="ham__icon" aria-hidden="true">
+      <span class="ham__bar ham__bar--1"></span>
+      <span class="ham__bar ham__bar--2"></span>
+      <span class="ham__bar ham__bar--3"></span>
+    </span>
+    <span class="ham__text"></span>
+  </button>
+  <a class="bs-logo" href="https://nicomalgeri.github.io/baja-below-surface/">
+    <img src="https://bajabelowsurface.com/wp-content/uploads/2025/07/logo1-scaled.png" alt="Baja Below Surface logo">
+  </a>
+</header>
 
 <!-- Fullscreen Menu -->
 <nav class="menu" id="menu" aria-hidden="true">

--- a/charter/index.html
+++ b/charter/index.html
@@ -18,11 +18,25 @@
     --z:99999;
   }
 
+  /* Sticky header with translucent blur */
+  .bs-header{
+    position:fixed; top:0; left:0; width:100%;
+    display:flex; justify-content:center; align-items:center;
+    padding:4px 0;
+    background:rgba(13,24,30,.35);
+    -webkit-backdrop-filter:blur(14px);
+    backdrop-filter:blur(14px);
+    z-index:var(--z);
+  }
+  .bs-logo{ width:48px; height:48px; display:block; margin:0 auto; }
+  .bs-logo img{ width:100%; height:100%; object-fit:contain; display:block; }
+
   /* Hamburger: yellow lines only, no hover bg */
   .ham{
-    position:fixed; top:clamp(10px,2vh,18px); left:clamp(10px,2vw,18px);
+    position:absolute;
+    left:clamp(10px,2vw,18px); top:50%; transform:translateY(-50%);
     width:48px; height:48px; border:0; background:transparent; padding:0; cursor:pointer;
-    display:grid; place-items:center; z-index:var(--z); border-radius:12px;
+    display:grid; place-items:center; border-radius:12px;
   }
   .ham:hover, .ham:focus, .ham:focus-visible{ background:transparent; box-shadow:none; outline:none; }
   .ham__icon{ width:24px; height:18px; position:relative; }
@@ -119,15 +133,20 @@
   /* Titles remain centered across all viewport widths */
 </style>
 
-<!-- Button -->
-<button class="ham" id="ham" aria-label="Open menu" aria-controls="menu" aria-expanded="false">
-  <span class="ham__icon" aria-hidden="true">
-    <span class="ham__bar ham__bar--1"></span>
-    <span class="ham__bar ham__bar--2"></span>
-    <span class="ham__bar ham__bar--3"></span>
-  </span>
-  <span class="ham__text"></span>
-</button>
+<!-- Sticky Header -->
+<header class="bs-header">
+  <button class="ham" id="ham" aria-label="Open menu" aria-controls="menu" aria-expanded="false">
+    <span class="ham__icon" aria-hidden="true">
+      <span class="ham__bar ham__bar--1"></span>
+      <span class="ham__bar ham__bar--2"></span>
+      <span class="ham__bar ham__bar--3"></span>
+    </span>
+    <span class="ham__text"></span>
+  </button>
+  <a class="bs-logo" href="https://nicomalgeri.github.io/baja-below-surface/">
+    <img src="https://bajabelowsurface.com/wp-content/uploads/2025/07/logo1-scaled.png" alt="Baja Below Surface logo">
+  </a>
+</header>
 
 <!-- Fullscreen Menu -->
 <nav class="menu" id="menu" aria-hidden="true">

--- a/day-trips/index.html
+++ b/day-trips/index.html
@@ -171,11 +171,25 @@
     --z:99999;
   }
 
+  /* Sticky header with translucent blur */
+  .bs-header{
+    position:fixed; top:0; left:0; width:100%;
+    display:flex; justify-content:center; align-items:center;
+    padding:4px 0;
+    background:rgba(13,24,30,.35);
+    -webkit-backdrop-filter:blur(14px);
+    backdrop-filter:blur(14px);
+    z-index:var(--z);
+  }
+  .bs-logo{ width:48px; height:48px; display:block; margin:0 auto; }
+  .bs-logo img{ width:100%; height:100%; object-fit:contain; display:block; }
+
   /* Hamburger: yellow lines only, no hover bg */
   .ham{
-    position:fixed; top:clamp(10px,2vh,18px); left:clamp(10px,2vw,18px);
+    position:absolute;
+    left:clamp(10px,2vw,18px); top:50%; transform:translateY(-50%);
     width:48px; height:48px; border:0; background:transparent; padding:0; cursor:pointer;
-    display:grid; place-items:center; z-index:var(--z); border-radius:12px;
+    display:grid; place-items:center; border-radius:12px;
   }
   .ham:hover, .ham:focus, .ham:focus-visible{ background:transparent; box-shadow:none; outline:none; }
   .ham__icon{ width:24px; height:18px; position:relative; }
@@ -272,15 +286,20 @@
   /* Titles remain centered across all viewport widths */
 </style>
 
-<!-- Button -->
-<button class="ham" id="ham" aria-label="Open menu" aria-controls="menu" aria-expanded="false">
-  <span class="ham__icon" aria-hidden="true">
-    <span class="ham__bar ham__bar--1"></span>
-    <span class="ham__bar ham__bar--2"></span>
-    <span class="ham__bar ham__bar--3"></span>
-  </span>
-  <span class="ham__text"></span>
-</button>
+<!-- Sticky Header -->
+<header class="bs-header">
+  <button class="ham" id="ham" aria-label="Open menu" aria-controls="menu" aria-expanded="false">
+    <span class="ham__icon" aria-hidden="true">
+      <span class="ham__bar ham__bar--1"></span>
+      <span class="ham__bar ham__bar--2"></span>
+      <span class="ham__bar ham__bar--3"></span>
+    </span>
+    <span class="ham__text"></span>
+  </button>
+  <a class="bs-logo" href="https://nicomalgeri.github.io/baja-below-surface/">
+    <img src="https://bajabelowsurface.com/wp-content/uploads/2025/07/logo1-scaled.png" alt="Baja Below Surface logo">
+  </a>
+</header>
 
 <!-- Fullscreen Menu -->
 <nav class="menu" id="menu" aria-hidden="true">

--- a/expeditions/index.html
+++ b/expeditions/index.html
@@ -142,11 +142,25 @@
     --z:99999;
   }
 
+  /* Sticky header with translucent blur */
+  .bs-header{
+    position:fixed; top:0; left:0; width:100%;
+    display:flex; justify-content:center; align-items:center;
+    padding:4px 0;
+    background:rgba(13,24,30,.35);
+    -webkit-backdrop-filter:blur(14px);
+    backdrop-filter:blur(14px);
+    z-index:var(--z);
+  }
+  .bs-logo{ width:48px; height:48px; display:block; margin:0 auto; }
+  .bs-logo img{ width:100%; height:100%; object-fit:contain; display:block; }
+
   /* Hamburger: yellow lines only, no hover bg */
   .ham{
-    position:fixed; top:clamp(10px,2vh,18px); left:clamp(10px,2vw,18px);
+    position:absolute;
+    left:clamp(10px,2vw,18px); top:50%; transform:translateY(-50%);
     width:48px; height:48px; border:0; background:transparent; padding:0; cursor:pointer;
-    display:grid; place-items:center; z-index:var(--z); border-radius:12px;
+    display:grid; place-items:center; border-radius:12px;
   }
   .ham:hover, .ham:focus, .ham:focus-visible{ background:transparent; box-shadow:none; outline:none; }
   .ham__icon{ width:24px; height:18px; position:relative; }
@@ -242,14 +256,20 @@
 
   /* Titles remain centered across all viewport widths */
 </style>
-<button class="ham" id="ham" aria-label="Open menu" aria-controls="menu" aria-expanded="false">
-  <span class="ham__icon" aria-hidden="true">
-    <span class="ham__bar ham__bar--1"></span>
-    <span class="ham__bar ham__bar--2"></span>
-    <span class="ham__bar ham__bar--3"></span>
-  </span>
-  <span class="ham__text"></span>
-</button>
+<!-- Sticky Header -->
+<header class="bs-header">
+  <button class="ham" id="ham" aria-label="Open menu" aria-controls="menu" aria-expanded="false">
+    <span class="ham__icon" aria-hidden="true">
+      <span class="ham__bar ham__bar--1"></span>
+      <span class="ham__bar ham__bar--2"></span>
+      <span class="ham__bar ham__bar--3"></span>
+    </span>
+    <span class="ham__text"></span>
+  </button>
+  <a class="bs-logo" href="https://nicomalgeri.github.io/baja-below-surface/">
+    <img src="https://bajabelowsurface.com/wp-content/uploads/2025/07/logo1-scaled.png" alt="Baja Below Surface logo">
+  </a>
+</header>
 
 <nav class="menu" id="menu" aria-hidden="true">
   <div class="menu__container">

--- a/index.html
+++ b/index.html
@@ -1940,11 +1940,25 @@ document.addEventListener('scroll',function(){
     --z:99999;
   }
 
+  /* Sticky header with translucent blur */
+  .bs-header{
+    position:fixed; top:0; left:0; width:100%;
+    display:flex; justify-content:center; align-items:center;
+    padding:4px 0;
+    background:rgba(13,24,30,.35);
+    -webkit-backdrop-filter:blur(14px);
+    backdrop-filter:blur(14px);
+    z-index:var(--z);
+  }
+  .bs-logo{ width:48px; height:48px; display:block; margin:0 auto; }
+  .bs-logo img{ width:100%; height:100%; object-fit:contain; display:block; }
+
   /* Hamburger: yellow lines only, no hover bg */
   .ham{
-    position:fixed; top:clamp(10px,2vh,18px); left:clamp(10px,2vw,18px);
+    position:absolute;
+    left:clamp(10px,2vw,18px); top:50%; transform:translateY(-50%);
     width:48px; height:48px; border:0; background:transparent; padding:0; cursor:pointer;
-    display:grid; place-items:center; z-index:var(--z); border-radius:12px;
+    display:grid; place-items:center; border-radius:12px;
   }
   .ham:hover, .ham:focus, .ham:focus-visible{ background:transparent; box-shadow:none; outline:none; }
   .ham__icon{ width:24px; height:18px; position:relative; }
@@ -2041,15 +2055,20 @@ document.addEventListener('scroll',function(){
   /* Titles remain centered across all viewport widths */
 </style>
 
-<!-- Button -->
-<button class="ham" id="ham" aria-label="Open menu" aria-controls="menu" aria-expanded="false">
-  <span class="ham__icon" aria-hidden="true">
-    <span class="ham__bar ham__bar--1"></span>
-    <span class="ham__bar ham__bar--2"></span>
-    <span class="ham__bar ham__bar--3"></span>
-  </span>
-  <span class="ham__text"></span>
-</button>
+<!-- Sticky Header -->
+<header class="bs-header">
+  <button class="ham" id="ham" aria-label="Open menu" aria-controls="menu" aria-expanded="false">
+    <span class="ham__icon" aria-hidden="true">
+      <span class="ham__bar ham__bar--1"></span>
+      <span class="ham__bar ham__bar--2"></span>
+      <span class="ham__bar ham__bar--3"></span>
+    </span>
+    <span class="ham__text"></span>
+  </button>
+  <a class="bs-logo" href="https://nicomalgeri.github.io/baja-below-surface/">
+    <img src="https://bajabelowsurface.com/wp-content/uploads/2025/07/logo1-scaled.png" alt="Baja Below Surface logo">
+  </a>
+</header>
 
 <!-- Fullscreen Menu -->
 <nav class="menu" id="menu" aria-hidden="true">


### PR DESCRIPTION
## Summary
- center sticky header logo aligned with hamburger menu
- apply translucent sticky header styling across site pages
- fix header padding to maintain uniform height across pages

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_689f851940e883209cd4f451fa3c096a