### PR TITLE
Center sticky header logo across site

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -72,7 +72,7 @@
   /* Sticky header with translucent blur */
   .bs-header{
     position:fixed; top:0; left:0; width:100%;
-    display:flex; justify-content:space-between; align-items:center;
+    display:flex; justify-content:center; align-items:center;
     padding:clamp(6px,1.5vh,12px) clamp(10px,2vw,18px);
     background:rgba(13,24,30,.35);
     -webkit-backdrop-filter:blur(14px);
@@ -84,7 +84,7 @@
 
   /* Hamburger: yellow lines only, no hover bg */
   .ham{
-    position:relative;
+    position:absolute; left:clamp(10px,2vw,18px); top:50%; transform:translateY(-50%);
     width:48px; height:48px; border:0; background:transparent; padding:0; cursor:pointer;
     display:grid; place-items:center; border-radius:12px;
   }

--- a/charter/index.html
+++ b/charter/index.html
@@ -21,7 +21,7 @@
   /* Sticky header with translucent blur */
   .bs-header{
     position:fixed; top:0; left:0; width:100%;
-    display:flex; justify-content:space-between; align-items:center;
+    display:flex; justify-content:center; align-items:center;
     padding:clamp(6px,1.5vh,12px) clamp(10px,2vw,18px);
     background:rgba(13,24,30,.35);
     -webkit-backdrop-filter:blur(14px);
@@ -33,7 +33,7 @@
 
   /* Hamburger: yellow lines only, no hover bg */
   .ham{
-    position:relative;
+    position:absolute; left:clamp(10px,2vw,18px); top:50%; transform:translateY(-50%);
     width:48px; height:48px; border:0; background:transparent; padding:0; cursor:pointer;
     display:grid; place-items:center; border-radius:12px;
   }

--- a/day-trips/index.html
+++ b/day-trips/index.html
@@ -175,7 +175,7 @@
   /* Sticky header with translucent blur */
   .bs-header{
     position:fixed; top:0; left:0; width:100%;
-    display:flex; justify-content:space-between; align-items:center;
+    display:flex; justify-content:center; align-items:center;
     padding:clamp(6px,1.5vh,12px) clamp(10px,2vw,18px);
     background:rgba(13,24,30,.35);
     -webkit-backdrop-filter:blur(14px);
@@ -187,7 +187,7 @@
 
   /* Hamburger: yellow lines only, no hover bg */
   .ham{
-    position:relative;
+    position:absolute; left:clamp(10px,2vw,18px); top:50%; transform:translateY(-50%);
     width:48px; height:48px; border:0; background:transparent; padding:0; cursor:pointer;
     display:grid; place-items:center; border-radius:12px;
   }

--- a/expeditions/index.html
+++ b/expeditions/index.html
@@ -145,7 +145,7 @@
   /* Sticky header with translucent blur */
   .bs-header{
     position:fixed; top:0; left:0; width:100%;
-    display:flex; justify-content:space-between; align-items:center;
+    display:flex; justify-content:center; align-items:center;
     padding:clamp(6px,1.5vh,12px) clamp(10px,2vw,18px);
     background:rgba(13,24,30,.35);
     -webkit-backdrop-filter:blur(14px);
@@ -157,7 +157,7 @@
 
   /* Hamburger: yellow lines only, no hover bg */
   .ham{
-    position:relative;
+    position:absolute; left:clamp(10px,2vw,18px); top:50%; transform:translateY(-50%);
     width:48px; height:48px; border:0; background:transparent; padding:0; cursor:pointer;
     display:grid; place-items:center; border-radius:12px;
   }

--- a/index.html
+++ b/index.html
@@ -1940,7 +1940,7 @@ document.addEventListener('scroll',function(){
   /* Sticky header with translucent blur */
   .bs-header{
     position:fixed; top:0; left:0; width:100%;
-    display:flex; justify-content:space-between; align-items:center;
+    display:flex; justify-content:center; align-items:center;
     padding:clamp(6px,1.5vh,12px) clamp(10px,2vw,18px);
     background:rgba(13,24,30,.35);
     -webkit-backdrop-filter:blur(14px);
@@ -1952,7 +1952,7 @@ document.addEventListener('scroll',function(){
 
   /* Hamburger: yellow lines only, no hover bg */
   .ham{
-    position:relative;
+    position:absolute; left:clamp(10px,2vw,18px); top:50%; transform:translateY(-50%);
     width:48px; height:48px; border:0; background:transparent; padding:0; cursor:pointer;
     display:grid; place-items:center; border-radius:12px;
   }


### PR DESCRIPTION
## Summary
- center sticky header logo across all pages
- pin hamburger menu to left to keep logo centered

## Testing
- `npx prettier about-us/index.html charter/index.html day-trips/index.html expeditions/index.html index.html --check` *(fails: code style issues)*

------
https://chatgpt.com/codex/tasks/task_e_689f8b8f96908320aaefdf7746e12dbf