### PR TITLE
Fix mobile hero scroll arrow placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -419,9 +419,10 @@
       .bs-hero__text {
         font-size: clamp(1rem, 4.6vw, 1.5rem);
       }
-      
+
       .bs-hero__scroll {
-        bottom: 24px;
+        bottom: 64px;
+        bottom: calc(env(safe-area-inset-bottom) + 64px);
         width: 44px;
         height: 44px;
       }


### PR DESCRIPTION
## Summary
- Move the homepage hero scroll arrow higher on small screens
- Offset arrow from device safe areas for better visibility

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_689f8cdb2cec8320906267f5580ab662