### PR TITLE
Ensure hamburger menu titles clear header

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -132,7 +132,11 @@
   .menu__center{
     grid-row:1;
     width:100%;
-    display:flex; align-items:center; justify-content:center;  /* TRUE vertical centering */
+    display:flex;
+    align-items:center;
+    justify-content:center;  /* TRUE vertical centering */
+    padding:clamp(80px,10vh,120px) 0;
+    box-sizing:border-box;
   }
 
   /* Menu list */

--- a/charter/index.html
+++ b/charter/index.html
@@ -81,7 +81,11 @@
   .menu__center{
     grid-row:1;
     width:100%;
-    display:flex; align-items:center; justify-content:center;  /* TRUE vertical centering */
+    display:flex;
+    align-items:center;
+    justify-content:center;  /* TRUE vertical centering */
+    padding:clamp(80px,10vh,120px) 0;
+    box-sizing:border-box;
   }
 
   /* Menu list */

--- a/day-trips/index.html
+++ b/day-trips/index.html
@@ -235,7 +235,11 @@
   .menu__center{
     grid-row:1;
     width:100%;
-    display:flex; align-items:center; justify-content:center;  /* TRUE vertical centering */
+    display:flex;
+    align-items:center;
+    justify-content:center;  /* TRUE vertical centering */
+    padding:clamp(80px,10vh,120px) 0;
+    box-sizing:border-box;
   }
 
   /* Menu list */

--- a/expeditions/index.html
+++ b/expeditions/index.html
@@ -205,7 +205,11 @@
   .menu__center{
     grid-row:1;
     width:100%;
-    display:flex; align-items:center; justify-content:center;  /* TRUE vertical centering */
+    display:flex;
+    align-items:center;
+    justify-content:center;  /* TRUE vertical centering */
+    padding:clamp(80px,10vh,120px) 0;
+    box-sizing:border-box;
   }
 
   /* Menu list */

--- a/index.html
+++ b/index.html
@@ -2000,7 +2000,11 @@ document.addEventListener('scroll',function(){
   .menu__center{
     grid-row:1;
     width:100%;
-    display:flex; align-items:center; justify-content:center;  /* TRUE vertical centering */
+    display:flex;
+    align-items:center;
+    justify-content:center;  /* TRUE vertical centering */
+    padding:clamp(80px,10vh,120px) 0;
+    box-sizing:border-box;
   }
 
   /* Menu list */


### PR DESCRIPTION
## Summary
- add top and bottom padding to `.menu__center` so first menu item no longer sits under the sticky header and spacing remains even

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f8d8bed5083209a11f2c3e28cf275