### PR TITLE
Adjust mobile hero scroll arrow spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -421,8 +421,8 @@
       }
 
       .bs-hero__scroll {
-        bottom: 64px;
-        bottom: calc(env(safe-area-inset-bottom) + 64px);
+        bottom: 32px;
+        bottom: calc(env(safe-area-inset-bottom) + 32px);
         width: 44px;
         height: 44px;
       }


### PR DESCRIPTION
## Summary
- tighten mobile spacing for the hero section's scroll arrow to keep it visible above the fold

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f9354a4c88320a45419d78501c189