### PR TITLE
Fix Day Trips grid layout

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -177,6 +177,12 @@ html, body {
   justify-content: center !important;
 }
 
+/* Day Trips: three columns on desktop */
+.daytrips .services__grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr)) !important;
+  max-width: 1100px !important;
+}
+
 /* Ensure cards are centered within their grid area */
 .services__card,
 .daytrips .services__card,
@@ -194,6 +200,10 @@ html, body {
     max-width: 400px !important;
     gap: 1.5rem !important;
     justify-content: center !important;
+  }
+  .daytrips .services__grid {
+    grid-template-columns: 1fr !important;
+    max-width: 400px !important;
   }
 }
 


### PR DESCRIPTION
## Summary
- Ensure Day Trips grid shows three cards per row on desktop
- Stack Day Trips cards into a single column on narrow screens

## Testing
- `npx --yes htmlhint day-trips/index.html expeditions/index.html`


------
https://chatgpt.com/codex/tasks/task_e_689f924253008320814aaead938379a3