### PR TITLE
Fix service card column layouts

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -168,8 +168,8 @@ html, body {
   align-items: center !important;
 }
 
-/* Expeditions and Charter: force single column layout on all screens */
-.expeditions .services__grid,
+/* Day Trips and Charter: force single column layout on all screens */
+.daytrips .services__grid,
 .charter .services__grid {
   grid-template-columns: 1fr !important;
   max-width: 400px !important;
@@ -177,8 +177,8 @@ html, body {
   justify-content: center !important;
 }
 
-/* Day Trips: three columns on desktop */
-.daytrips .services__grid {
+/* Expeditions: three columns on desktop */
+.expeditions .services__grid {
   grid-template-columns: repeat(3, minmax(0, 1fr)) !important;
   max-width: 1100px !important;
 }
@@ -200,10 +200,6 @@ html, body {
     max-width: 400px !important;
     gap: 1.5rem !important;
     justify-content: center !important;
-  }
-  .daytrips .services__grid {
-    grid-template-columns: 1fr !important;
-    max-width: 400px !important;
   }
 }
 


### PR DESCRIPTION
## Summary
- Ensure Day Trips and Charter sections always use a single-column card layout
- Display Expeditions cards in three columns on desktop and one column on mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f9b5d918c83208de9b9b8ea7d77fb