### PR TITLE
Add vertical padding around About Us title

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1091,10 +1091,12 @@ body.scrolled .elementor-location-header {
   flex-direction: column;
   align-items: center;
   justify-content: center; /* vertical centring */
+  padding: var(--bs-section-padding) clamp(2rem, 6vw, 6rem);
 }
 
 .about__title {
   margin: 0; /* remove extra margin */
+  padding: clamp(1.5rem, 5vh, 2.5rem) 0;
 }
 /* About page layout */
 .about__wrap {


### PR DESCRIPTION
## Summary
- Add responsive padding to the About Us section to create space above the title.
- Apply top and bottom padding to the About Us heading for clearer separation from content.

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f9bef1e5c832088b51d5d89e7a588