### PR TITLE
Add background image to About Us section

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -243,12 +243,14 @@ html, body {
   margin-left: -50vw;
   margin-right: -50vw;
   padding: clamp(4rem,10vh,6rem) clamp(2rem,6vw,6rem);
-  background: linear-gradient(
-    to bottom,
-    rgba(0,0,0,0.25),
-    rgba(0,0,0,0.55) 60%,
-    rgba(0,0,0,0.65)
-  );
+  background:
+    linear-gradient(
+      to bottom,
+      rgba(0,0,0,0.25),
+      rgba(0,0,0,0.55) 60%,
+      rgba(0,0,0,0.65)
+    ),
+    url("https://server359.web-hosting.com:2083/cpsess6570885596/frontend/jupiter/filemanager/showfile.html?file=About%20Us.jpeg&fileop=&dir=%2Fhome%2Fbajaalgn%2Fpublic_html%2Fassets%2FMedia&dirop=&charset=&file_charset=&baseurl=&basedir=") center center / cover no-repeat;
   color: #fff;
   isolation: isolate;
   overflow: visible;


### PR DESCRIPTION
## Summary
- set About Us section background to provided image and center it on all devices

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fa4b6303483208ca651c7df8b5478