### PR TITLE
feat: add separate mobile and desktop hero videos

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,8 @@
 
   <link rel="stylesheet" href="assets/css/main.css">
   <link rel="preconnect" href="https://bajabelowsurface.com">
-  <link rel="preload" href="https://bajabelowsurface.com/wp-content/uploads/2025/08/Main-Video-Responsive.mov" as="video" type="video/mp4">
+  <link rel="preload" href="https://bajabelowsurface.com/assets/Media/Main%20Video%20Responsive.mov" as="video" type="video/mp4" media="(max-width: 767px)">
+  <link rel="preload" href="https://bajabelowsurface.com/assets/Media/Main%20Video.mov" as="video" type="video/mp4" media="(min-width: 768px)">
 
   <style>
     /* ========================================
@@ -500,20 +501,21 @@
   <div class="bs-container">
   <div class="bs-hero-wrapper">
       <!-- Video Background -->
-      <video
-        id="bsMainVideo"
-        class="bs-hero-video bs-loading"
-        poster="https://bajabelowsurface.com/wp-content/uploads/2025/08/WhatsApp-Image-2025-08-12-at-21.09.42-scaled.jpeg"
-        autoplay
-        muted
-        loop
-        playsinline
-        preload="metadata"
-        aria-hidden="true"
-      >
-        <source src="https://bajabelowsurface.com/wp-content/uploads/2025/08/Main-Video-Responsive.mov" type="video/mp4">
-        <div class="bs-sr-only">Your browser does not support the video tag.</div>
-      </video>
+        <video
+          id="bsMainVideo"
+          class="bs-hero-video bs-loading"
+          poster="https://bajabelowsurface.com/wp-content/uploads/2025/08/WhatsApp-Image-2025-08-12-at-21.09.42-scaled.jpeg"
+          autoplay
+          muted
+          loop
+          playsinline
+          preload="metadata"
+          aria-hidden="true"
+        >
+          <source src="https://bajabelowsurface.com/assets/Media/Main%20Video%20Responsive.mov" type="video/mp4" media="(max-width: 767px)">
+          <source src="https://bajabelowsurface.com/assets/Media/Main%20Video.mov" type="video/mp4" media="(min-width: 768px)">
+          <div class="bs-sr-only">Your browser does not support the video tag.</div>
+        </video>
       
       <div class="bs-hero-overlay" aria-hidden="true"></div>
 


### PR DESCRIPTION
## Summary
- load dedicated mobile and desktop hero videos

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fa514c590832085e38d37b902cd75