### PR TITLE
Replace about-us hero image

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -18,7 +18,7 @@
   <div class="about__wrap">
     <div class="about__row reverse">
       <figure class="about__media" aria-hidden="true">
-        <img src="https://bajabelowsurface.com/wp-content/uploads/2025/08/Untitled-design-2.png" alt="Guide at sea">
+        <img src="https://previews.dropbox.com/p/thumb/ACu8jrpwBRW9uCqIU9ywrcSzfUUrlg05tPA9oqxEEAsncMGduonUK3z2h_8kl8hl4MzEeR8wkgy2o6r58kNO2dgTot2uOLpCqMBDSmJWcgVPaoFfNSZADCvYv1w4a-N04KYe9bHQ2czlvAfFb1B4DcmdAjn40otalmreLnVe4E0blBnD80l5z4DZFwNNRIKApP4CTzUEWClQcfu3xnqYcudG0cO2INJWLiRSJvVBa2uOYlNc9WRoqBDUPb2h53-wYYCMOg8aHhqMmgdZONEFi47h_TE8mzn_BXIpTuXefsxe7jDFpzUbJkS3hXMNOUQ7E24/p.png" alt="Guide at sea">
       </figure>
       <article class="about__panel">
         <h3 class="about__heading">Who We Are</h3>


### PR DESCRIPTION
## Summary
- Use new Dropbox-hosted image as hero photograph on the About Us page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fab5cd2b08320807b7fe812b09595