### PR TITLE
Reduce hamburger menu spacing for visible contact links

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -135,7 +135,7 @@
     display:flex;
     align-items:center;
     justify-content:center;  /* TRUE vertical centering */
-    padding:clamp(120px,15vh,160px) 0;
+    padding:clamp(40px,10vh,100px) 0;
     box-sizing:border-box;
   }
 
@@ -168,9 +168,9 @@
   }
 
   /* Socials pinned bottom */
-  .mini-icons{
+  .menu .mini-icons{
     width:100%; display:flex; flex-direction:column; align-items:center; gap:10px;
-    padding: 16px 0 28px;
+    padding: 8px 0 16px;
   }
   .mini-pair{ display:flex; align-items:center; gap:10px; white-space:nowrap; }
   .mini-icon{

--- a/charter/index.html
+++ b/charter/index.html
@@ -84,7 +84,7 @@
     display:flex;
     align-items:center;
     justify-content:center;  /* TRUE vertical centering */
-    padding:clamp(120px,15vh,160px) 0;
+    padding:clamp(40px,10vh,100px) 0;
     box-sizing:border-box;
   }
 
@@ -117,9 +117,9 @@
   }
 
   /* Socials pinned bottom */
-  .mini-icons{
+  .menu .mini-icons{
     width:100%; display:flex; flex-direction:column; align-items:center; gap:10px;
-    padding: 16px 0 28px;
+    padding: 8px 0 16px;
   }
   .mini-pair{ display:flex; align-items:center; gap:10px; white-space:nowrap; }
   .mini-icon{

--- a/day-trips/index.html
+++ b/day-trips/index.html
@@ -244,7 +244,7 @@
     display:flex;
     align-items:center;
     justify-content:center;  /* TRUE vertical centering */
-    padding:clamp(120px,15vh,160px) 0;
+    padding:clamp(40px,10vh,100px) 0;
     box-sizing:border-box;
   }
 
@@ -277,9 +277,9 @@
   }
 
   /* Socials pinned bottom */
-  .mini-icons{
+  .menu .mini-icons{
     width:100%; display:flex; flex-direction:column; align-items:center; gap:10px;
-    padding: 16px 0 28px;
+    padding: 8px 0 16px;
   }
   .mini-pair{ display:flex; align-items:center; gap:10px; white-space:nowrap; }
   .mini-icon{

--- a/expeditions/index.html
+++ b/expeditions/index.html
@@ -208,7 +208,7 @@
     display:flex;
     align-items:center;
     justify-content:center;  /* TRUE vertical centering */
-    padding:clamp(120px,15vh,160px) 0;
+    padding:clamp(40px,10vh,100px) 0;
     box-sizing:border-box;
   }
 
@@ -241,9 +241,9 @@
   }
 
   /* Socials pinned bottom */
-  .mini-icons{
+  .menu .mini-icons{
     width:100%; display:flex; flex-direction:column; align-items:center; gap:10px;
-    padding: 16px 0 28px;
+    padding: 8px 0 16px;
   }
   .mini-pair{ display:flex; align-items:center; gap:10px; white-space:nowrap; }
   .mini-icon{

--- a/index.html
+++ b/index.html
@@ -2058,7 +2058,7 @@ document.addEventListener('scroll',function(){
     display:flex;
     align-items:center;
     justify-content:center;  /* TRUE vertical centering */
-    padding:clamp(120px,15vh,160px) 0;
+    padding:clamp(40px,10vh,100px) 0;
     box-sizing:border-box;
   }
 
@@ -2091,9 +2091,9 @@ document.addEventListener('scroll',function(){
   }
 
   /* Socials pinned bottom */
-  .mini-icons{
+  .menu .mini-icons{
     width:100%; display:flex; flex-direction:column; align-items:center; gap:10px;
-    padding: 16px 0 28px;
+    padding: 8px 0 16px;
   }
   .mini-pair{ display:flex; align-items:center; gap:10px; white-space:nowrap; }
   .mini-icon{


### PR DESCRIPTION
## Summary
- Decrease vertical padding of hamburger menu titles so contact links sit closer to the navigation items
- Tighten spacing around menu social icons and scope styles to the menu to keep Instagram and email visible on all pages

## Testing
- `npm test` *(fails: ENOENT cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fb6f3d6748320bba9cafa408dd783