### PR TITLE
Fix mobile day trip card layout

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1271,3 +1271,10 @@ body.scrolled .elementor-location-header {
   background: #21262d;
   color: #f5e6af;
 }
+
+/* Force single-column layout on Day Trips for mobile screens */
+@media (max-width: 768px) {
+  .daytrips .services__grid {
+    grid-template-columns: 1fr !important;
+  }
+}


### PR DESCRIPTION
## Summary
- force Day Trips cards into a single column on mobile via media query

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fbe894ad48320aa184982e5e1a6d5