### PR TITLE
Ensure Day Trips cards stack on mobile

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1250,3 +1250,22 @@ body.scrolled .elementor-location-header {
   color: #f5e6af;
 }
 
+/* ===== DAY TRIPS: MOBILE LAYOUT MATCHING EXPEDITIONS ===== */
+@media (max-width: 768px) {
+  .daytrips .services__grid {
+    grid-template-columns: 1fr !important;
+    gap: 1.5rem !important;
+    max-width: none !important;
+  }
+
+  .daytrips .services__card {
+    max-width: 100% !important;
+  }
+
+  .daytrips .services__img {
+    width: 100% !important;
+    height: auto !important;
+    border-radius: 32px 32px 0 0 !important;
+  }
+}
+


### PR DESCRIPTION
## Summary
- Align Day Trips card layout with Expeditions on mobile via new responsive CSS rule.
- Make service grid single-column at ≤768px and allow cards/images to take full width.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fc4cd3ffc83209c334d51aaec43c4