### PR TITLE
Add charter page layout matching expeditions style

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -609,9 +609,10 @@ html, body {
   }
 }
 
-/* ===== DAY TRIPS & EXPEDITIONS SECTION ===== */
+/* ===== DAY TRIPS, EXPEDITIONS & CHARTER SECTION ===== */
 .daytrips.section,
-.expeditions.section {
+.expeditions.section,
+.charter.section {
   position: relative;
   width: 100vw;
   left: 50%;
@@ -624,9 +625,13 @@ html, body {
 .expeditions.section {
     background: url("https://www.dropbox.com/scl/fi/0m8m1nep88t3xouqk1xxb/Expeditions-Photo.jpeg?rlkey=dr2x71m7at8bn69h724lekta9&raw=1") center/cover no-repeat;
 }
+.charter.section {
+    background: url("https://www.dropbox.com/scl/fi/jby8gnjuw2f4woceofvpw/Sharks.jpg?rlkey=fgqpa6ul4fi9uu2l49of66lvp&raw=1") center/cover no-repeat;
+}
 
 .daytrips .services__heading,
-.expeditions .services__heading {
+.expeditions .services__heading,
+.charter .services__heading {
   text-align: center;
   font: 700 clamp(2rem,4vw,3rem)/1.2 inherit;
   color: var(--highlight);
@@ -634,7 +639,8 @@ html, body {
 }
 
 .daytrips .services__desc,
-.expeditions .services__desc {
+.expeditions .services__desc,
+.charter .services__desc {
   max-width: 600px;
   margin: 0 auto clamp(3rem,6vh,4rem);
   text-align: center;
@@ -643,15 +649,9 @@ html, body {
   line-height: 1.4;
 }
 
-.daytrips .services__grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px,1fr));
-  gap: clamp(1.5rem,4vw,2.5rem);
-  justify-content: center;
-  justify-items: center;
-}
-
-.expeditions .services__grid {
+.daytrips .services__grid,
+.expeditions .services__grid,
+.charter .services__grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px,1fr));
   gap: clamp(1.5rem,4vw,2.5rem);
@@ -667,7 +667,8 @@ html, body {
 }
 
 .daytrips .services__card,
-.expeditions .services__card {
+.expeditions .services__card,
+.charter .services__card {
   --ft: 10s;
   width: 100%;
   max-width: 360px;
@@ -681,7 +682,8 @@ html, body {
 }
 
 .daytrips .services__img,
-.expeditions .services__img {
+.expeditions .services__img,
+.charter .services__img {
   width: 100%;
   aspect-ratio: 16/9;
   background-size: cover;
@@ -692,7 +694,8 @@ html, body {
 }
 
 .daytrips .services__overlay,
-.expeditions .services__overlay {
+.expeditions .services__overlay,
+.charter .services__overlay {
   padding: clamp(1.5rem,2.4vw,2.4rem) clamp(1.5rem,2.4vw,2.6rem);
   background: rgba(33,38,45,0.7);
   border-bottom-left-radius: 32px;
@@ -705,7 +708,8 @@ html, body {
 }
 
 .daytrips .services__title,
-.expeditions .services__title {
+.expeditions .services__title,
+.charter .services__title {
   margin: 0 0 .75rem;
   font-size: clamp(1.4rem,2.5vw,1.8rem);
   font-weight: 700;
@@ -713,7 +717,8 @@ html, body {
 }
 
 .daytrips .services__text,
-.expeditions .services__text {
+.expeditions .services__text,
+.charter .services__text {
   margin: 0 0 1.5rem;
   font-size: clamp(.95rem,1.2vw,1.1rem);
   line-height: 1.5;
@@ -722,7 +727,8 @@ html, body {
 }
 
 .daytrips .services__btn,
-.expeditions .services__btn {
+.expeditions .services__btn,
+.charter .services__btn {
   align-self: flex-start;
   background: var(--highlight);
   color: var(--ink);
@@ -735,19 +741,22 @@ html, body {
 }
 
 .daytrips .services__btn:hover,
-.expeditions .services__btn:hover {
+.expeditions .services__btn:hover,
+.charter .services__btn:hover {
   background: #fff;
   transform: translateY(-2px);
 }
 
 .daytrips .services__card:hover,
-.expeditions .services__card:hover {
+.expeditions .services__card:hover,
+.charter .services__card:hover {
   transform: scale(1.05);
   box-shadow: 0 20px 60px rgba(0,0,0,0.7);
 }
 
 .daytrips .services__card:hover .services__overlay,
-.expeditions .services__card:hover .services__overlay {
+.expeditions .services__card:hover .services__overlay,
+.charter .services__card:hover .services__overlay {
   background: rgba(33,38,45,0.85);
   box-shadow: inset 0 0 20px rgba(255,255,255,0.2);
   filter: brightness(1.05) contrast(1.05);
@@ -761,7 +770,8 @@ html, body {
   }
 
   .daytrips .services__heading,
-  .expeditions .services__heading {
+  .expeditions .services__heading,
+  .charter .services__heading {
     font-size: clamp(1.8rem,8vw,2.4rem);
   }
 }
@@ -945,7 +955,8 @@ body.scrolled .elementor-location-header {
   .contact__panel,
   .whatsapp-button,
   .daytrips .services__card,
-  .expeditions .services__card {
+  .expeditions .services__card,
+  .charter .services__card {
     animation: none !important;
   }
   
@@ -960,7 +971,8 @@ body.scrolled .elementor-location-header {
 .review__nav:focus,
 .contact__btn:focus,
 .daytrips .services__btn:focus,
-.expeditions .services__btn:focus {
+.expeditions .services__btn:focus,
+.charter .services__btn:focus {
   outline: 2px solid var(--highlight);
   outline-offset: 3px;
 }

--- a/charter/index.html
+++ b/charter/index.html
@@ -1,14 +1,69 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width,initial-scale=1">
-    <title>Charter – Below Surface</title>
-    <meta name="description" content="Charter">
-    <link rel="stylesheet" href="../assets/css/main.css">
-  </head>
-  <body>
-<!-- ===== Hamburger Menu (titles centered; socials pinned bottom) ===== -->
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Charter – Below Surface</title>
+  <meta name="description" content="Charter" />
+  <link rel="stylesheet" href="../assets/css/main.css" />
+</head>
+<body>
+
+<section class="charter section" id="charter" aria-label="Charter">
+  <h2 class="services__heading">Charter</h2>
+  <p class="services__desc" style="max-width:600px; margin:0 auto 3rem; text-align:center; font-size:clamp(1.1rem,2vw,1.4rem); color:var(--text-light);">
+    Choose from our adventure-ready boats.
+  </p>
+
+  <div class="services__grid">
+
+    <!-- Mangata -->
+    <div class="services__card" style="--i:0">
+      <div class="services__img"
+           style="background-image:url('https://www.dropbox.com/scl/fi/5byvbqo4cr9k9v7vshezw/Boat.jpg?rlkey=17laykgdh1pp3kqy62yc46yqr&raw=1');">
+      </div>
+      <div class="services__overlay">
+        <h3 class="services__title">Mangata</h3>
+        <p class="services__text">Our adventure diving boat.</p>
+        <a class="services__btn"
+           href="https://wa.me/526242104724?text=Hi!%20I%20want%20to%20book%20the%20Mangata%20charter.">
+          Book
+        </a>
+      </div>
+    </div>
+
+    <!-- Siete mares -->
+    <div class="services__card" style="--i:1">
+      <div class="services__img"
+           style="background-image:url('https://www.dropbox.com/scl/fi/kclwgxg8us4irplse2rks/Charter-Luxury.jpg?rlkey=4k802w7dyk48n8n6q4uc48vev&raw=1');">
+      </div>
+      <div class="services__overlay">
+        <h3 class="services__title">Siete mares</h3>
+        <p class="services__text">Our adventure luxury boat.</p>
+        <a class="services__btn"
+           href="https://wa.me/526242104724?text=Hi!%20I%20want%20to%20book%20the%20Siete%20mares%20charter.">
+          Book
+        </a>
+      </div>
+    </div>
+
+  </div>
+</section>
+
+<!-- WhatsApp Floating Button -->
+<a
+  href="https://wa.me/526242104724"
+  class="whatsapp-button"
+  target="_blank"
+  aria-label="Chat on WhatsApp">
+  <img
+    src="https://www.svgrepo.com/show/303280/whatsapp-glyph-black-logo.svg"
+    alt="WhatsApp"
+    style="width:2rem;height:2rem;display:block;"
+  />
+</a>
+
+<!-- ===== Hamburger Menu ===== -->
 <style>
   :root{
     --accent:#f6e7b0;     /* yellow tone */
@@ -123,19 +178,19 @@
   }
   .mini-pair{ display:flex; align-items:center; gap:10px; white-space:nowrap; }
   .mini-icon{
-    --size:26px; --pad:8px;
-    display:inline-flex; align-items:center; justify-content:center;
-    width:calc(var(--size) + var(--pad)*2); height:calc(var(--size) + var(--pad)*2);
-    color:var(--accent); background:transparent; border-radius:999px; text-decoration:none;
-    transition:background .2s ease, transform .05s ease; flex-shrink:0;
+    --size:26px;
+    width:var(--size); height:var(--size); display:block; color:var(--accent);
+    transition:transform .3s ease;
   }
-  .mini-icon:hover{ background:var(--accent); color:var(--ink); }
+  .mini-icon:hover{ transform:scale(1.1); }
   .mini-icon svg{ width:var(--size); height:var(--size); display:block; }
   .contact__icon-text{ color:var(--accent); font-weight:600; font-size:1rem; }
 
   /* Titles remain centered across all viewport widths */
+  @media (max-width:600px){
+    .menu__center{ padding:80px 0; }
+  }
 </style>
-
 <!-- Sticky Header -->
 <header class="bs-header">
   <button class="ham" id="ham" aria-label="Open menu" aria-controls="menu" aria-expanded="false">
@@ -151,10 +206,8 @@
   </a>
 </header>
 
-<!-- Fullscreen Menu -->
 <nav class="menu" id="menu" aria-hidden="true">
   <div class="menu__container">
-    <!-- CENTERED TITLES AREA -->
     <div class="menu__center">
       <ul class="menu__list" role="menu" aria-label="Main menu">
         <li role="none"><a class="menu__link" role="menuitem" href="https://nicomalgeri.github.io/baja-below-surface/" style="--delay:.00s">Home</a></li>
@@ -164,8 +217,6 @@
         <li role="none"><a class="menu__link" role="menuitem" href="https://nicomalgeri.github.io/baja-below-surface/about-us" style="--delay:.32s">About Us</a></li>
       </ul>
     </div>
-
-    <!-- SOCIALS AT BOTTOM -->
     <div class="mini-icons">
       <div class="mini-pair">
         <a class="mini-icon" href="https://instagram.com/bajabelowsurface" aria-label="Instagram" target="_blank" rel="noopener">
@@ -190,13 +241,6 @@
   </div>
 </nav>
 
-<main>
-  <section class="page-hero"><h1>Charter</h1><p>Replace with full content.</p></section>
-</main>
-<footer class="site-footer">
-  <p>© Below Surface</p>
-</footer>
-
 <script>
 (function(){
   const btn = document.getElementById('ham');
@@ -205,7 +249,6 @@
   const hamText = btn.querySelector('.ham__text');
   let lastFocus = null;
 
-  // Ensure ONLY one active link
   const norm = (u)=>{ try{ const x=new URL(u, location.origin); return (x.origin+x.pathname+x.search).replace(/\/+$/,''); } catch(e){ return u; } };
   const here = norm(location.href);
   links.forEach(l => { l.classList.remove('is-active'); l.removeAttribute('aria-current'); });
@@ -249,6 +292,9 @@
   links.forEach(a => a.addEventListener('click', closeMenu));
 })();
 </script>
+
 <script src="../assets/js/dropbox.js"></script>
-  </body>
+
+</body>
 </html>
+


### PR DESCRIPTION
## Summary
- Implement charter page using expeditions layout with two boat cards (Mangata and Siete mares)
- Extend CSS to style charter section and apply shark background image
- Include WhatsApp booking links and ensure responsive grid styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fc6f6777c8320b43585d4a85ada4d