### PR TITLE
Align Day Trips page styling with Expeditions

### DIFF
--- a/day-trips/index.html
+++ b/day-trips/index.html
@@ -9,7 +9,7 @@
 </head>
 <body>
 
-<section class="day trips section" id="day-trips" aria-label="Day Trips">
+<section class="daytrips section" id="day-trips" aria-label="Day Trips">
   <h2 class="services__heading">Day Trips</h2>
   <p class="services__desc" style="max-width:600px; margin:0 auto 3rem; text-align:center; font-size:clamp(1.1rem,2vw,1.4rem); color:var(--text-light);">
    Discover our handpicked day‑trip adventures—dive, snorkel, and explore beneath the waves in unforgettable style.
@@ -360,10 +360,6 @@
 })();
 </script>
 
-<script src="../assets/js/dropbox.js"></script>
-
-</body>
-</html>
 <script src="../assets/js/dropbox.js"></script>
 
 </body>


### PR DESCRIPTION
## Summary
- Apply the `daytrips` section class so Day Trips uses the same grid styling as Expeditions.
- Remove duplicated Dropbox script and stray closing tags at the end of the file.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a031b531e08320b04696fb0c6f13a7