### PR TITLE
fix: adjust day trips cards on mobile

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1267,11 +1267,13 @@ body.scrolled .elementor-location-header {
   .daytrips .services__grid {
     grid-template-columns: 1fr !important;
     gap: 1.5rem !important;
-    max-width: none !important;
+    max-width: 400px !important;
+    justify-content: center !important;
   }
 
   .daytrips .services__card {
-    max-width: 100% !important;
+    max-width: 360px !important;
+    margin: 0 auto !important;
   }
 
   .daytrips .services__img {


### PR DESCRIPTION
## Summary
- tune day trips mobile grid and card widths for proper centering

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0367a04ec8320b5a9b2079ec116ed