### PR TITLE
Add expedition card images and unify booking button style

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -728,7 +728,8 @@ html, body {
 
 .daytrips .services__btn,
 .expeditions .services__btn,
-.charter .services__btn {
+.charter .services__btn,
+.exp-cta .services__btn {
   align-self: flex-start;
   background: var(--highlight);
   color: var(--ink);
@@ -742,7 +743,8 @@ html, body {
 
 .daytrips .services__btn:hover,
 .expeditions .services__btn:hover,
-.charter .services__btn:hover {
+.charter .services__btn:hover,
+.exp-cta .services__btn:hover {
   background: #fff;
   transform: translateY(-2px);
 }
@@ -972,7 +974,8 @@ body.scrolled .elementor-location-header {
 .contact__btn:focus,
 .daytrips .services__btn:focus,
 .expeditions .services__btn:focus,
-.charter .services__btn:focus {
+.charter .services__btn:focus,
+.exp-cta .services__btn:focus {
   outline: 2px solid var(--highlight);
   outline-offset: 3px;
 }
@@ -1312,8 +1315,10 @@ body.scrolled .elementor-location-header {
 .exp-note{ font-weight: 600; color: #e7eef1; }
 .exp-price{ font-weight: 700; color: #fff; }
 
+.exp-img{ width:100%; aspect-ratio:16/9; border-radius:32px; overflow:hidden; }
+.exp-img img{ width:100%; height:100%; object-fit:cover; display:block; }
+
 .exp-cta{ display:flex; justify-content:center; padding: .5rem 0 1rem; }
-.exp-cta .services__btn{ /* reuse existing .services__btn style */ }
 @media (max-width: 768px){
   .exp-body{ grid-template-columns: 1fr; }
 }

--- a/expeditions/diving-in-the-sea-of-cortez/index.html
+++ b/expeditions/diving-in-the-sea-of-cortez/index.html
@@ -118,6 +118,9 @@
   </section>
 
   <section class="exp-body">
+    <figure class="exp-img">
+      <img src="https://www.dropbox.com/scl/fi/4s51oc7uzpuzzxnw1j28l/Sea-of-Cortez-Private-Liveaboard.jpeg?rlkey=79ci5evs5yqkbyejlyzmm2l85&raw=1" alt="Diving the Sea of Cortez" />
+    </figure>
     <article class="exp-block">
       <h2>Overview</h2>
       <ul class="exp-list">

--- a/expeditions/medical-sardine-run/index.html
+++ b/expeditions/medical-sardine-run/index.html
@@ -118,6 +118,9 @@
   </section>
 
   <section class="exp-body">
+    <figure class="exp-img">
+      <img src="https://www.dropbox.com/scl/fi/o18wt3l35tqe36dhmf63e/Sardine.jpg?rlkey=i4uf3fuzds1e7w9ok88zlzwcb&raw=1" alt="Mexican Sardine Run" />
+    </figure>
     <article class="exp-block">
       <h2>Overview</h2>
       <ul class="exp-list">

--- a/expeditions/mobulas-and-cetaceans/index.html
+++ b/expeditions/mobulas-and-cetaceans/index.html
@@ -118,6 +118,9 @@
   </section>
 
   <section class="exp-body">
+    <figure class="exp-img">
+      <img src="https://www.dropbox.com/scl/fi/emqto8l62yi4m41sraani/MOBULAS-AND-CETACEANS.jpeg?rlkey=urnxcejgtdbm9isgbhf793des&raw=1" alt="Mobulas and Cetaceans" />
+    </figure>
     <article class="exp-block">
       <h2>Overview</h2>
       <ul class="exp-list">

--- a/expeditions/sea-of-cortez-private-liveaboard/index.html
+++ b/expeditions/sea-of-cortez-private-liveaboard/index.html
@@ -118,6 +118,9 @@
   </section>
 
   <section class="exp-body">
+    <figure class="exp-img">
+      <img src="https://www.dropbox.com/scl/fi/4s51oc7uzpuzzxnw1j28l/Sea-of-Cortez-Private-Liveaboard.jpeg?rlkey=79ci5evs5yqkbyejlyzmm2l85&raw=1" alt="Sea of Cortez Private Liveaboard" />
+    </figure>
     <article class="exp-block">
       <h2>Overview</h2>
       <ul class="exp-list">

--- a/expeditions/socorro-island-liveaboard/index.html
+++ b/expeditions/socorro-island-liveaboard/index.html
@@ -118,6 +118,9 @@
   </section>
 
   <section class="exp-body">
+    <figure class="exp-img">
+      <img src="https://www.dropbox.com/scl/fi/4ufoln6gfsnusgqom59n1/Socorro-Island.jpeg?rlkey=oyp9po023sbepe8na504rlyux&raw=1" alt="Socorro Island Liveaboard" />
+    </figure>
     <article class="exp-block">
       <h2>Overview</h2>
       <ul class="exp-list">

--- a/expeditions/winter-whales/index.html
+++ b/expeditions/winter-whales/index.html
@@ -118,6 +118,9 @@
   </section>
 
   <section class="exp-body">
+    <figure class="exp-img">
+      <img src="https://www.dropbox.com/scl/fi/k8uv8gk7lg0k3mu03yo7g/WINTER-WHALES.jpg?rlkey=kb19flw7933mnisthy183wxmn&raw=1" alt="Winter Whales" />
+    </figure>
     <article class="exp-block">
       <h2>Overview</h2>
       <ul class="exp-list">


### PR DESCRIPTION
## Summary
- Show each expedition's card image before its overview.
- Style Book buttons with the same call-to-action appearance as expedition cards.
- Add reusable `.exp-img` helper in main stylesheet.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a03d8911048320869b9983676b7d6c