### PR TITLE
feat: add page-specific backgrounds

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="../assets/css/main.css" />
 
 </head>
-<body>
+<body style="background:url('https://bajabelowsurface.com/wp-content/uploads/2025/07/Giant-Manta_-scaled.jpg') center center / cover no-repeat;">
 
 <!-- ============ ABOUT (FULL-WIDTH, ONE BACKGROUND, ALTERNATING PANELS, CENTER TITLE) ============ -->
 <section class="about" id="About" aria-label="About Us">

--- a/charter/index.html
+++ b/charter/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="Charter">
     <link rel="stylesheet" href="../assets/css/main.css">
   </head>
-  <body>
+  <body style="background:url('https://static.wixstatic.com/media/f8cc86_033e438c58ac4d669eb7b840a153ae09~mv2.jpg/v1/crop/x_277,y_0,w_3231,h_3785/fill/w_572,h_670,al_c,q_85,usm_0.66_1.00_0.01,enc_avif,quality_auto/_B2A6998-Editar.jpg') center center / cover no-repeat;">
 <!-- ===== Hamburger Menu (titles centered; socials pinned bottom) ===== -->
 <style>
   :root{

--- a/day-trips/index.html
+++ b/day-trips/index.html
@@ -8,7 +8,7 @@
     <!-- Link to full site stylesheet -->
     <link rel="stylesheet" href="../assets/css/main.css">
   </head>
-  <body>
+  <body style="background:url('https://bajabelowsurface.com/wp-content/uploads/2025/07/Humpback-Whale.jpg') center center / cover no-repeat;">
 
 <section class="daytrips section" id="daytrips" aria-label="Day Trips">
   <h2 class="services__heading">Day Trips</h2>

--- a/expeditions/index.html
+++ b/expeditions/index.html
@@ -7,7 +7,7 @@
   <meta name="description" content="Expeditions" />
   <link rel="stylesheet" href="../assets/css/main.css" />
 </head>
-<body>
+<body style="background:url('https://bajabelowsurface.com/wp-content/uploads/2025/07/Sea-Lion-Snorkel-1.avif') center center / cover no-repeat;">
 
 <section class="expeditions section" id="expeditions" aria-label="Expeditions">
   <h2 class="services__heading">Expeditions</h2>


### PR DESCRIPTION
## Summary
- add centered background image to Day Trips page
- apply unique centered backgrounds to Expeditions, About Us, and Charter pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f9331432c8320bb9acb96911e04e6