### PR TITLE
Make social menu text clickable

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -226,7 +226,7 @@
             <circle cx="17.5" cy="6.5" r="1"></circle>
           </svg>
         </a>
-        <span class="contact__icon-text">@bajabelowsurface</span>
+        <a class="contact__icon-text" href="https://instagram.com/bajabelowsurface" target="_blank" rel="noopener">@bajabelowsurface</a>
       </div>
       <div class="mini-pair">
         <a class="mini-icon" href="mailto:dani@bajabelowsurface.com" aria-label="Email">
@@ -236,7 +236,7 @@
             <path d="M3 7l9 6 9-6"></path>
           </svg>
         </a>
-        <span class="contact__icon-text">dani@bajabelowsurface.com</span>
+        <a class="contact__icon-text" href="mailto:dani@bajabelowsurface.com">dani@bajabelowsurface.com</a>
       </div>
     </div>
   </div>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1048,6 +1048,7 @@ body.scrolled .elementor-location-header {
   font-weight: 600;
   font-size: 1rem;
   text-align: center;
+  text-decoration: none;
 }
 
 .mini-icon {
@@ -1223,6 +1224,7 @@ body.scrolled .elementor-location-header {
   overflow: hidden;
   text-overflow: ellipsis;
   text-align: center;
+  text-decoration: none;
 }
 @media (max-width: 640px) {
   .mini-icons {

--- a/charter/index.html
+++ b/charter/index.html
@@ -226,7 +226,7 @@
             <circle cx="17.5" cy="6.5" r="1"></circle>
           </svg>
         </a>
-        <span class="contact__icon-text">@bajabelowsurface</span>
+        <a class="contact__icon-text" href="https://instagram.com/bajabelowsurface" target="_blank" rel="noopener">@bajabelowsurface</a>
       </div>
       <div class="mini-pair">
         <a class="mini-icon" href="mailto:dani@bajabelowsurface.com" aria-label="Email">
@@ -235,7 +235,7 @@
             <path d="M3 7l9 6 9-6"></path>
           </svg>
         </a>
-        <span class="contact__icon-text">dani@bajabelowsurface.com</span>
+        <a class="contact__icon-text" href="mailto:dani@bajabelowsurface.com">dani@bajabelowsurface.com</a>
       </div>
     </div>
   </div>

--- a/day-trips/index.html
+++ b/day-trips/index.html
@@ -293,7 +293,7 @@
             <circle cx="17.5" cy="6.5" r="1"></circle>
           </svg>
         </a>
-        <span class="contact__icon-text">@bajabelowsurface</span>
+        <a class="contact__icon-text" href="https://instagram.com/bajabelowsurface" target="_blank" rel="noopener">@bajabelowsurface</a>
       </div>
       <div class="mini-pair">
         <a class="mini-icon" href="mailto:dani@bajabelowsurface.com" aria-label="Email">
@@ -302,7 +302,7 @@
             <path d="M3 7l9 6 9-6"></path>
           </svg>
         </a>
-        <span class="contact__icon-text">dani@bajabelowsurface.com</span>
+        <a class="contact__icon-text" href="mailto:dani@bajabelowsurface.com">dani@bajabelowsurface.com</a>
       </div>
     </div>
   </div>

--- a/expeditions/diving-in-the-sea-of-cortez/index.html
+++ b/expeditions/diving-in-the-sea-of-cortez/index.html
@@ -96,7 +96,7 @@
             <circle cx="17.5" cy="6.5" r="1"></circle>
           </svg>
         </a>
-        <span class="contact__icon-text">@bajabelowsurface</span>
+        <a class="contact__icon-text" href="https://instagram.com/bajabelowsurface" target="_blank" rel="noopener">@bajabelowsurface</a>
       </div>
       <div class="mini-pair">
         <a class="mini-icon" href="mailto:dani@bajabelowsurface.com" aria-label="Email">
@@ -105,7 +105,7 @@
             <path d="M3 7l9 6 9-6"></path>
           </svg>
         </a>
-        <span class="contact__icon-text">dani@bajabelowsurface.com</span>
+        <a class="contact__icon-text" href="mailto:dani@bajabelowsurface.com">dani@bajabelowsurface.com</a>
       </div>
     </div>
   </div>

--- a/expeditions/index.html
+++ b/expeditions/index.html
@@ -279,7 +279,7 @@
             <circle cx="17.5" cy="6.5" r="1"></circle>
           </svg>
         </a>
-        <span class="contact__icon-text">@bajabelowsurface</span>
+        <a class="contact__icon-text" href="https://instagram.com/bajabelowsurface" target="_blank" rel="noopener">@bajabelowsurface</a>
       </div>
       <div class="mini-pair">
         <a class="mini-icon" href="mailto:dani@bajabelowsurface.com" aria-label="Email">
@@ -288,7 +288,7 @@
             <path d="M3 7l9 6 9-6"></path>
           </svg>
         </a>
-        <span class="contact__icon-text">dani@bajabelowsurface.com</span>
+        <a class="contact__icon-text" href="mailto:dani@bajabelowsurface.com">dani@bajabelowsurface.com</a>
       </div>
     </div>
   </div>

--- a/expeditions/medical-sardine-run/index.html
+++ b/expeditions/medical-sardine-run/index.html
@@ -96,7 +96,7 @@
             <circle cx="17.5" cy="6.5" r="1"></circle>
           </svg>
         </a>
-        <span class="contact__icon-text">@bajabelowsurface</span>
+        <a class="contact__icon-text" href="https://instagram.com/bajabelowsurface" target="_blank" rel="noopener">@bajabelowsurface</a>
       </div>
       <div class="mini-pair">
         <a class="mini-icon" href="mailto:dani@bajabelowsurface.com" aria-label="Email">
@@ -105,7 +105,7 @@
             <path d="M3 7l9 6 9-6"></path>
           </svg>
         </a>
-        <span class="contact__icon-text">dani@bajabelowsurface.com</span>
+        <a class="contact__icon-text" href="mailto:dani@bajabelowsurface.com">dani@bajabelowsurface.com</a>
       </div>
     </div>
   </div>

--- a/expeditions/mobulas-and-cetaceans/index.html
+++ b/expeditions/mobulas-and-cetaceans/index.html
@@ -96,7 +96,7 @@
             <circle cx="17.5" cy="6.5" r="1"></circle>
           </svg>
         </a>
-        <span class="contact__icon-text">@bajabelowsurface</span>
+        <a class="contact__icon-text" href="https://instagram.com/bajabelowsurface" target="_blank" rel="noopener">@bajabelowsurface</a>
       </div>
       <div class="mini-pair">
         <a class="mini-icon" href="mailto:dani@bajabelowsurface.com" aria-label="Email">
@@ -105,7 +105,7 @@
             <path d="M3 7l9 6 9-6"></path>
           </svg>
         </a>
-        <span class="contact__icon-text">dani@bajabelowsurface.com</span>
+        <a class="contact__icon-text" href="mailto:dani@bajabelowsurface.com">dani@bajabelowsurface.com</a>
       </div>
     </div>
   </div>

--- a/expeditions/sea-of-cortez-private-liveaboard/index.html
+++ b/expeditions/sea-of-cortez-private-liveaboard/index.html
@@ -96,7 +96,7 @@
             <circle cx="17.5" cy="6.5" r="1"></circle>
           </svg>
         </a>
-        <span class="contact__icon-text">@bajabelowsurface</span>
+        <a class="contact__icon-text" href="https://instagram.com/bajabelowsurface" target="_blank" rel="noopener">@bajabelowsurface</a>
       </div>
       <div class="mini-pair">
         <a class="mini-icon" href="mailto:dani@bajabelowsurface.com" aria-label="Email">
@@ -105,7 +105,7 @@
             <path d="M3 7l9 6 9-6"></path>
           </svg>
         </a>
-        <span class="contact__icon-text">dani@bajabelowsurface.com</span>
+        <a class="contact__icon-text" href="mailto:dani@bajabelowsurface.com">dani@bajabelowsurface.com</a>
       </div>
     </div>
   </div>

--- a/expeditions/socorro-island-liveaboard/index.html
+++ b/expeditions/socorro-island-liveaboard/index.html
@@ -96,7 +96,7 @@
             <circle cx="17.5" cy="6.5" r="1"></circle>
           </svg>
         </a>
-        <span class="contact__icon-text">@bajabelowsurface</span>
+        <a class="contact__icon-text" href="https://instagram.com/bajabelowsurface" target="_blank" rel="noopener">@bajabelowsurface</a>
       </div>
       <div class="mini-pair">
         <a class="mini-icon" href="mailto:dani@bajabelowsurface.com" aria-label="Email">
@@ -105,7 +105,7 @@
             <path d="M3 7l9 6 9-6"></path>
           </svg>
         </a>
-        <span class="contact__icon-text">dani@bajabelowsurface.com</span>
+        <a class="contact__icon-text" href="mailto:dani@bajabelowsurface.com">dani@bajabelowsurface.com</a>
       </div>
     </div>
   </div>

--- a/expeditions/winter-whales/index.html
+++ b/expeditions/winter-whales/index.html
@@ -96,7 +96,7 @@
             <circle cx="17.5" cy="6.5" r="1"></circle>
           </svg>
         </a>
-        <span class="contact__icon-text">@bajabelowsurface</span>
+        <a class="contact__icon-text" href="https://instagram.com/bajabelowsurface" target="_blank" rel="noopener">@bajabelowsurface</a>
       </div>
       <div class="mini-pair">
         <a class="mini-icon" href="mailto:dani@bajabelowsurface.com" aria-label="Email">
@@ -105,7 +105,7 @@
             <path d="M3 7l9 6 9-6"></path>
           </svg>
         </a>
-        <span class="contact__icon-text">dani@bajabelowsurface.com</span>
+        <a class="contact__icon-text" href="mailto:dani@bajabelowsurface.com">dani@bajabelowsurface.com</a>
       </div>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -1852,7 +1852,7 @@
               <circle cx="17.5" cy="6.5" r="1"></circle>
             </svg>
           </a>
-          <span class="contact__icon-text">@bajabelowsurface</span>
+          <a class="contact__icon-text" href="https://instagram.com/bajabelowsurface" target="_blank" rel="noopener">@bajabelowsurface</a>
         </div>
 
         <div class="mini-pair">
@@ -1863,7 +1863,7 @@
               <path d="M3 7l9 6 9-6"></path>
             </svg>
           </a>
-          <span class="contact__icon-text">dani@bajabelowsurface.com</span>
+          <a class="contact__icon-text" href="mailto:dani@bajabelowsurface.com">dani@bajabelowsurface.com</a>
         </div>
       </div>
 
@@ -2167,7 +2167,7 @@ document.addEventListener('scroll',function(){
             <circle cx="17.5" cy="6.5" r="1"></circle>
           </svg>
         </a>
-        <span class="contact__icon-text">@bajabelowsurface</span>
+        <a class="contact__icon-text" href="https://instagram.com/bajabelowsurface" target="_blank" rel="noopener">@bajabelowsurface</a>
       </div>
       <div class="mini-pair">
         <a class="mini-icon" href="mailto:dani@bajabelowsurface.com" aria-label="Email">
@@ -2177,7 +2177,7 @@ document.addEventListener('scroll',function(){
             <path d="M3 7l9 6 9-6"></path>
           </svg>
         </a>
-        <span class="contact__icon-text">dani@bajabelowsurface.com</span>
+        <a class="contact__icon-text" href="mailto:dani@bajabelowsurface.com">dani@bajabelowsurface.com</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Wrap Instagram handle and email text in hamburger menus with same links as their icons across all pages
- Ensure text links in contact sections are also clickable
- Prevent underline on new links via `.contact__icon-text` styling

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a05704e09083208acf47dd2410390e