### PR TITLE
Ensure gallery video thumbnail shows on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -1486,8 +1486,9 @@
 
   <div class="bs-video-column">
     <div class="bs-video-wrapper">
-      <video id="bsGalleryVideo" playsinline preload="metadata" poster="https://previews.dropbox.com/p/thumb/ACvvlCWcoUpbm9HatgOVxjQSbjON6mZP25KoHhqngcyXOQJ2whjmR4EZjtw14RIrvOaerfn8cBYLoA2hinC-soBJ9OGBenFBv8SRMXaSA0ite-3LYKI9WETJDZNfPX5yqMtMaYipXkU50HHfw2CQOgUbvRy3xz4bwue6hnI2CLEyGEcw-BWS_RknyWBE0gkBTJyhaXii4KQ_3rIB0AmxIvtw0r56hxWbiY9R4dBWf1miMjH43lOcoYsvOver3PHx-ZP1_8l1GElVQ6t5CKNHN1h-CwgAeRsmQwCBnBoRXOrQicfHVzYKSvn7P64yeJclmxg/p.jpeg">
-        <source src="https://www.dropbox.com/scl/fi/dwr71773bzfcfvi64rqn8/Main-Video.mov?rlkey=5hmsrj1fjqy86kja6nzlkclok&raw=1" type="video/mp4">
+      <video id="bsGalleryVideo" playsinline preload="metadata" poster="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Desktop%20Static.png?raw=true">
+        <source src="https://www.dropbox.com/scl/fi/1it20errhgmn8ts5rpif1/Main-Video-Mobile.mov?rlkey=ifu73s7nn0xebyzasgofgons6&raw=1" type="video/mp4" media="(max-width: 767px)">
+        <source src="https://www.dropbox.com/scl/fi/dwr71773bzfcfvi64rqn8/Main-Video.mov?rlkey=5hmsrj1fjqy86kja6nzlkclok&raw=1" type="video/mp4" media="(min-width: 768px)">
         Your browser does not support the video tag.
       </video>
       <button class="bs-video-play" id="bsVideoPlay" aria-label="Play Video"></button>


### PR DESCRIPTION
## Summary
- Display the gallery video preview on mobile with the same thumbnail as desktop.
- Add responsive video sources so mobile devices use the optimized clip while sharing a common poster.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0572743ec8320b92a89bcbdba2af9