### PR TITLE
Use consistent sticky header logo

### DIFF
--- a/charter/index.html
+++ b/charter/index.html
@@ -202,7 +202,7 @@
     <span class="ham__text"></span>
   </button>
   <a class="bs-logo" href="https://nicomalgeri.github.io/baja-below-surface/">
-    <img src="https://uc7928edac4eb9278eef5b4e6c7b.previews.dropboxusercontent.com/p/thumb/ACuOC0MUfsJZriIeG4v5MdKO5XpcYKDTrqFR6MtTUJH5eI9OVxYBGZQH-99HsytdlvmUkq9VwdNJPvE9jYNQT5WnISjLbUOG0oGp_ZFvkf2hDGZvtN8PeJHxrRlGZw6jJd4XeBuu3n-x4Z4d3qCkVStFU28UsJaBLh6T1y01jl9s6mCtVO-GLKeBKKKg72E7-449n4kYDg5XbkNlnKoWIzuzY6dOi_dLWllGaukACJuj7oNUwnp_0k_Dv1YVGWP-t8PzMrod2BFMlNxkv8yuQbfDZXgGhz_Xfdh46QsFxqnATp2zJn-T0SMFsVr3ZaYpHf3rL8Wp_BbRpJ-eCVYWHC4ZA5R83VhTpJsZd5DS2M6B5jTmaUaSot7IW3XvOKi22AjxYPC4DE9QcfMgFIgkfHj3/p.png?is_prewarmed=true" alt="Baja Below Surface logo">
+    <img src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/logo1-scaled.png?raw=true" alt="Baja Below Surface logo">
   </a>
 </header>
 

--- a/expeditions/diving-in-the-sea-of-cortez/index.html
+++ b/expeditions/diving-in-the-sea-of-cortez/index.html
@@ -73,7 +73,7 @@
     <span class="ham__text"></span>
   </button>
   <a class="bs-logo" href="https://nicomalgeri.github.io/baja-below-surface/">
-    <img src="https://uc7928edac4eb9278eef5b4e6c7b.previews.dropboxusercontent.com/p/thumb/ACuOC0MUfsJZriIeG4v5MdKO5XpcYKDTrqFR6MtTUJH5eI9OVxYBGZQH-99HsytdlvmUkq9VwdNJPvE9jYNQT5WnISjLbUOG0oGp_ZFvkf2hDGZvtN8PeJHxrRlGZw6jJd4XeBuu3n-x4Z4d3qCkVStFU28UsJaBLh6T1y01jl9s6mCtVO-GLKeBKKKg72E7-449n4kYDg5XbkNlnKoWIzuzY6dOi_dLWllGaukACJuj7oNUwnp_0k_Dv1YVGWP-t8PzMrod2BFMlNxkv8yuQbfDZXgGhz_Xfdh46QsFxqnATp2zJn-T0SMFsVr3ZaYpHf3rL8Wp_BbRpJ-eCVYWHC4ZA5R83VhTpJsZd5DS2M6B5jTmaUaSot7IW3XvOKi22AjxYPC4DE9QcfMgFIgkfHj3/p.png?is_prewarmed=true" alt="Baja Below Surface logo">
+    <img src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/logo1-scaled.png?raw=true" alt="Baja Below Surface logo">
   </a>
 </header>
 <nav class="menu" id="menu" aria-hidden="true">

--- a/expeditions/medical-sardine-run/index.html
+++ b/expeditions/medical-sardine-run/index.html
@@ -73,7 +73,7 @@
     <span class="ham__text"></span>
   </button>
   <a class="bs-logo" href="https://nicomalgeri.github.io/baja-below-surface/">
-    <img src="https://uc7928edac4eb9278eef5b4e6c7b.previews.dropboxusercontent.com/p/thumb/ACuOC0MUfsJZriIeG4v5MdKO5XpcYKDTrqFR6MtTUJH5eI9OVxYBGZQH-99HsytdlvmUkq9VwdNJPvE9jYNQT5WnISjLbUOG0oGp_ZFvkf2hDGZvtN8PeJHxrRlGZw6jJd4XeBuu3n-x4Z4d3qCkVStFU28UsJaBLh6T1y01jl9s6mCtVO-GLKeBKKKg72E7-449n4kYDg5XbkNlnKoWIzuzY6dOi_dLWllGaukACJuj7oNUwnp_0k_Dv1YVGWP-t8PzMrod2BFMlNxkv8yuQbfDZXgGhz_Xfdh46QsFxqnATp2zJn-T0SMFsVr3ZaYpHf3rL8Wp_BbRpJ-eCVYWHC4ZA5R83VhTpJsZd5DS2M6B5jTmaUaSot7IW3XvOKi22AjxYPC4DE9QcfMgFIgkfHj3/p.png?is_prewarmed=true" alt="Baja Below Surface logo">
+    <img src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/logo1-scaled.png?raw=true" alt="Baja Below Surface logo">
   </a>
 </header>
 <nav class="menu" id="menu" aria-hidden="true">

--- a/expeditions/mobulas-and-cetaceans/index.html
+++ b/expeditions/mobulas-and-cetaceans/index.html
@@ -73,7 +73,7 @@
     <span class="ham__text"></span>
   </button>
   <a class="bs-logo" href="https://nicomalgeri.github.io/baja-below-surface/">
-    <img src="https://uc7928edac4eb9278eef5b4e6c7b.previews.dropboxusercontent.com/p/thumb/ACuOC0MUfsJZriIeG4v5MdKO5XpcYKDTrqFR6MtTUJH5eI9OVxYBGZQH-99HsytdlvmUkq9VwdNJPvE9jYNQT5WnISjLbUOG0oGp_ZFvkf2hDGZvtN8PeJHxrRlGZw6jJd4XeBuu3n-x4Z4d3qCkVStFU28UsJaBLh6T1y01jl9s6mCtVO-GLKeBKKKg72E7-449n4kYDg5XbkNlnKoWIzuzY6dOi_dLWllGaukACJuj7oNUwnp_0k_Dv1YVGWP-t8PzMrod2BFMlNxkv8yuQbfDZXgGhz_Xfdh46QsFxqnATp2zJn-T0SMFsVr3ZaYpHf3rL8Wp_BbRpJ-eCVYWHC4ZA5R83VhTpJsZd5DS2M6B5jTmaUaSot7IW3XvOKi22AjxYPC4DE9QcfMgFIgkfHj3/p.png?is_prewarmed=true" alt="Baja Below Surface logo">
+    <img src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/logo1-scaled.png?raw=true" alt="Baja Below Surface logo">
   </a>
 </header>
 <nav class="menu" id="menu" aria-hidden="true">

--- a/expeditions/sea-of-cortez-private-liveaboard/index.html
+++ b/expeditions/sea-of-cortez-private-liveaboard/index.html
@@ -73,7 +73,7 @@
     <span class="ham__text"></span>
   </button>
   <a class="bs-logo" href="https://nicomalgeri.github.io/baja-below-surface/">
-    <img src="https://uc7928edac4eb9278eef5b4e6c7b.previews.dropboxusercontent.com/p/thumb/ACuOC0MUfsJZriIeG4v5MdKO5XpcYKDTrqFR6MtTUJH5eI9OVxYBGZQH-99HsytdlvmUkq9VwdNJPvE9jYNQT5WnISjLbUOG0oGp_ZFvkf2hDGZvtN8PeJHxrRlGZw6jJd4XeBuu3n-x4Z4d3qCkVStFU28UsJaBLh6T1y01jl9s6mCtVO-GLKeBKKKg72E7-449n4kYDg5XbkNlnKoWIzuzY6dOi_dLWllGaukACJuj7oNUwnp_0k_Dv1YVGWP-t8PzMrod2BFMlNxkv8yuQbfDZXgGhz_Xfdh46QsFxqnATp2zJn-T0SMFsVr3ZaYpHf3rL8Wp_BbRpJ-eCVYWHC4ZA5R83VhTpJsZd5DS2M6B5jTmaUaSot7IW3XvOKi22AjxYPC4DE9QcfMgFIgkfHj3/p.png?is_prewarmed=true" alt="Baja Below Surface logo">
+    <img src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/logo1-scaled.png?raw=true" alt="Baja Below Surface logo">
   </a>
 </header>
 <nav class="menu" id="menu" aria-hidden="true">

--- a/expeditions/socorro-island-liveaboard/index.html
+++ b/expeditions/socorro-island-liveaboard/index.html
@@ -73,7 +73,7 @@
     <span class="ham__text"></span>
   </button>
   <a class="bs-logo" href="https://nicomalgeri.github.io/baja-below-surface/">
-    <img src="https://uc7928edac4eb9278eef5b4e6c7b.previews.dropboxusercontent.com/p/thumb/ACuOC0MUfsJZriIeG4v5MdKO5XpcYKDTrqFR6MtTUJH5eI9OVxYBGZQH-99HsytdlvmUkq9VwdNJPvE9jYNQT5WnISjLbUOG0oGp_ZFvkf2hDGZvtN8PeJHxrRlGZw6jJd4XeBuu3n-x4Z4d3qCkVStFU28UsJaBLh6T1y01jl9s6mCtVO-GLKeBKKKg72E7-449n4kYDg5XbkNlnKoWIzuzY6dOi_dLWllGaukACJuj7oNUwnp_0k_Dv1YVGWP-t8PzMrod2BFMlNxkv8yuQbfDZXgGhz_Xfdh46QsFxqnATp2zJn-T0SMFsVr3ZaYpHf3rL8Wp_BbRpJ-eCVYWHC4ZA5R83VhTpJsZd5DS2M6B5jTmaUaSot7IW3XvOKi22AjxYPC4DE9QcfMgFIgkfHj3/p.png?is_prewarmed=true" alt="Baja Below Surface logo">
+    <img src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/logo1-scaled.png?raw=true" alt="Baja Below Surface logo">
   </a>
 </header>
 <nav class="menu" id="menu" aria-hidden="true">

--- a/expeditions/winter-whales/index.html
+++ b/expeditions/winter-whales/index.html
@@ -73,7 +73,7 @@
     <span class="ham__text"></span>
   </button>
   <a class="bs-logo" href="https://nicomalgeri.github.io/baja-below-surface/">
-    <img src="https://uc7928edac4eb9278eef5b4e6c7b.previews.dropboxusercontent.com/p/thumb/ACuOC0MUfsJZriIeG4v5MdKO5XpcYKDTrqFR6MtTUJH5eI9OVxYBGZQH-99HsytdlvmUkq9VwdNJPvE9jYNQT5WnISjLbUOG0oGp_ZFvkf2hDGZvtN8PeJHxrRlGZw6jJd4XeBuu3n-x4Z4d3qCkVStFU28UsJaBLh6T1y01jl9s6mCtVO-GLKeBKKKg72E7-449n4kYDg5XbkNlnKoWIzuzY6dOi_dLWllGaukACJuj7oNUwnp_0k_Dv1YVGWP-t8PzMrod2BFMlNxkv8yuQbfDZXgGhz_Xfdh46QsFxqnATp2zJn-T0SMFsVr3ZaYpHf3rL8Wp_BbRpJ-eCVYWHC4ZA5R83VhTpJsZd5DS2M6B5jTmaUaSot7IW3XvOKi22AjxYPC4DE9QcfMgFIgkfHj3/p.png?is_prewarmed=true" alt="Baja Below Surface logo">
+    <img src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/logo1-scaled.png?raw=true" alt="Baja Below Surface logo">
   </a>
 </header>
 <nav class="menu" id="menu" aria-hidden="true">


### PR DESCRIPTION
## Summary
- replace remaining dropbox-based sticky header logos with the repo-hosted logo

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a05b3646808320ab0a926f228f86c2