### PR TITLE
Use GitHub-hosted background on expeditions page

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -629,7 +629,7 @@ html, body {
   isolation: isolate;
 }
 .expeditions.section {
-    background: url("https://www.dropbox.com/scl/fi/0m8m1nep88t3xouqk1xxb/Expeditions-Photo.jpeg?rlkey=dr2x71m7at8bn69h724lekta9&st=b5jc3lmw&raw=1") center center/cover no-repeat;
+    background: url("https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Expeditions%20Photo.jpeg?raw=true") center center/cover no-repeat;
 }
 .charter.section {
     background: url("https://www.dropbox.com/scl/fi/jby8gnjuw2f4woceofvpw/Sharks.jpg?rlkey=fgqpa6ul4fi9uu2l49of66lvp&raw=1") center/cover no-repeat;


### PR DESCRIPTION
## Summary
- switch Expeditions page background to the repo-hosted image

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a05b564e60832081855ecbcf5a5dc1