### PR TITLE
fix: top-center about background on mobile

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -253,7 +253,7 @@ html, body {
 
 @media (max-width: 768px) {
   .about {
-    background-position: bottom center;
+    background-position: top center;
   }
 }
 


### PR DESCRIPTION
## Summary
- align About Us background image to top center on small screens

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a05b6d8f108320a1975ef70659d15b