### PR TITLE
Improve site load speed with image lazy-loading

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -18,7 +18,7 @@
   <div class="about__wrap">
     <div class="about__row reverse">
       <figure class="about__media" aria-hidden="true">
-        <img src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Dani%20Tormo%20Sub.jpg?raw=true" alt="Dani Tormo">
+        <img loading="lazy" src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Dani%20Tormo%20Sub.jpg?raw=true" alt="Dani Tormo">
       </figure>
       <article class="about__panel">
         <h3 class="about__heading">Who We Are</h3>
@@ -32,7 +32,7 @@
 
     <div class="about__row" id="Meet-Dani">
       <figure class="about__media" aria-hidden="true">
-        <img src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Dani%20Tormo.png?raw=true" alt="Dani - Founder & Expedition Leader">
+        <img loading="lazy" src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Dani%20Tormo.png?raw=true" alt="Dani - Founder & Expedition Leader">
       </figure>
       <article class="about__panel">
         <h3 class="about__heading">Meet Dani — Founder & Expedition Leader</h3>
@@ -53,6 +53,7 @@
   aria-label="Chat on WhatsApp"
 >
   <img
+    loading="lazy"
     src="https://www.svgrepo.com/show/303280/whatsapp-glyph-black-logo.svg"
     alt="WhatsApp"
     style="width:2rem;height:2rem;display:block;"

--- a/charter/index.html
+++ b/charter/index.html
@@ -57,6 +57,7 @@
   target="_blank"
   aria-label="Chat on WhatsApp">
   <img
+    loading="lazy"
     src="https://www.svgrepo.com/show/303280/whatsapp-glyph-black-logo.svg"
     alt="WhatsApp"
     style="width:2rem;height:2rem;display:block;"

--- a/day-trips/index.html
+++ b/day-trips/index.html
@@ -125,6 +125,7 @@
   target="_blank"
   aria-label="Chat on WhatsApp">
   <img
+    loading="lazy"
     src="https://www.svgrepo.com/show/303280/whatsapp-glyph-black-logo.svg"
     alt="WhatsApp"
     style="width:2rem;height:2rem;display:block;"

--- a/expeditions/diving-in-the-sea-of-cortez/index.html
+++ b/expeditions/diving-in-the-sea-of-cortez/index.html
@@ -122,7 +122,7 @@
       <a class="services__btn" href="https://wa.me/526242104724?text=Hi%20Below%20Surface!%20I%27d%20like%20to%20book%20the%20Sea%20of%20Cortez%20Diving" rel="noreferrer" target="_blank">Book</a>
     </div>
     <figure class="exp-img">
-      <img src="https://www.dropbox.com/scl/fi/4s51oc7uzpuzzxnw1j28l/Sea-of-Cortez-Private-Liveaboard.jpeg?rlkey=79ci5evs5yqkbyejlyzmm2l85&raw=1" alt="Diving the Sea of Cortez" />
+      <img loading="lazy" src="https://www.dropbox.com/scl/fi/4s51oc7uzpuzzxnw1j28l/Sea-of-Cortez-Private-Liveaboard.jpeg?rlkey=79ci5evs5yqkbyejlyzmm2l85&raw=1" alt="Diving the Sea of Cortez" />
     </figure>
     <article class="exp-block">
       <h2>Overview</h2>
@@ -173,7 +173,7 @@
   </section>
 </main>
 <a href="https://wa.me/526242104724" class="whatsapp-button" target="_blank" aria-label="Chat on WhatsApp">
-  <img src="https://www.svgrepo.com/show/303280/whatsapp-glyph-black-logo.svg" alt="WhatsApp" style="width:2rem;height:2rem;display:block;" />
+  <img loading="lazy" src="https://www.svgrepo.com/show/303280/whatsapp-glyph-black-logo.svg" alt="WhatsApp" style="width:2rem;height:2rem;display:block;" />
 </a>
 <script>
 document.addEventListener('scroll',function(){

--- a/expeditions/index.html
+++ b/expeditions/index.html
@@ -111,6 +111,7 @@
   target="_blank"
   aria-label="Chat on WhatsApp">
   <img
+    loading="lazy"
     src="https://www.svgrepo.com/show/303280/whatsapp-glyph-black-logo.svg"
     alt="WhatsApp"
     style="width:2rem;height:2rem;display:block;"

--- a/expeditions/medical-sardine-run/index.html
+++ b/expeditions/medical-sardine-run/index.html
@@ -122,7 +122,7 @@
       <a class="services__btn" href="https://wa.me/526242104724?text=Hi%20Below%20Surface!%20I%27d%20like%20to%20book%20the%20Mexican%20Sardine%20Run" rel="noreferrer" target="_blank">Book</a>
     </div>
     <figure class="exp-img">
-      <img src="https://www.dropbox.com/scl/fi/o18wt3l35tqe36dhmf63e/Sardine.jpg?rlkey=i4uf3fuzds1e7w9ok88zlzwcb&raw=1" alt="Mexican Sardine Run" />
+      <img loading="lazy" src="https://www.dropbox.com/scl/fi/o18wt3l35tqe36dhmf63e/Sardine.jpg?rlkey=i4uf3fuzds1e7w9ok88zlzwcb&raw=1" alt="Mexican Sardine Run" />
     </figure>
     <article class="exp-block">
       <h2>Overview</h2>
@@ -176,7 +176,7 @@
   </section>
 </main>
 <a href="https://wa.me/526242104724" class="whatsapp-button" target="_blank" aria-label="Chat on WhatsApp">
-  <img src="https://www.svgrepo.com/show/303280/whatsapp-glyph-black-logo.svg" alt="WhatsApp" style="width:2rem;height:2rem;display:block;" />
+  <img loading="lazy" src="https://www.svgrepo.com/show/303280/whatsapp-glyph-black-logo.svg" alt="WhatsApp" style="width:2rem;height:2rem;display:block;" />
 </a>
 <script>
 document.addEventListener('scroll',function(){

--- a/expeditions/mobulas-and-cetaceans/index.html
+++ b/expeditions/mobulas-and-cetaceans/index.html
@@ -122,7 +122,7 @@
       <a class="services__btn" href="https://wa.me/526242104724?text=Hi%20Below%20Surface!%20I%27d%20like%20to%20book%20the%20Mobulas%20%26%20Cetaceans" rel="noreferrer" target="_blank">Book</a>
     </div>
     <figure class="exp-img">
-      <img src="https://www.dropbox.com/scl/fi/emqto8l62yi4m41sraani/MOBULAS-AND-CETACEANS.jpeg?rlkey=urnxcejgtdbm9isgbhf793des&raw=1" alt="Mobulas and Cetaceans" />
+      <img loading="lazy" src="https://www.dropbox.com/scl/fi/emqto8l62yi4m41sraani/MOBULAS-AND-CETACEANS.jpeg?rlkey=urnxcejgtdbm9isgbhf793des&raw=1" alt="Mobulas and Cetaceans" />
     </figure>
     <article class="exp-block">
       <h2>Overview</h2>
@@ -174,7 +174,7 @@
   </section>
 </main>
 <a href="https://wa.me/526242104724" class="whatsapp-button" target="_blank" aria-label="Chat on WhatsApp">
-  <img src="https://www.svgrepo.com/show/303280/whatsapp-glyph-black-logo.svg" alt="WhatsApp" style="width:2rem;height:2rem;display:block;" />
+  <img loading="lazy" src="https://www.svgrepo.com/show/303280/whatsapp-glyph-black-logo.svg" alt="WhatsApp" style="width:2rem;height:2rem;display:block;" />
 </a>
 <script>
 document.addEventListener('scroll',function(){

--- a/expeditions/sea-of-cortez-private-liveaboard/index.html
+++ b/expeditions/sea-of-cortez-private-liveaboard/index.html
@@ -122,7 +122,7 @@
       <a class="services__btn" href="https://wa.me/526242104724?text=Hi%20Below%20Surface!%20I%27d%20like%20to%20book%20the%20Sea%20of%20Cortez%20Private%20Liveaboard" rel="noreferrer" target="_blank">Book</a>
     </div>
     <figure class="exp-img">
-      <img src="https://www.dropbox.com/scl/fi/4s51oc7uzpuzzxnw1j28l/Sea-of-Cortez-Private-Liveaboard.jpeg?rlkey=79ci5evs5yqkbyejlyzmm2l85&raw=1" alt="Sea of Cortez Private Liveaboard" />
+      <img loading="lazy" src="https://www.dropbox.com/scl/fi/4s51oc7uzpuzzxnw1j28l/Sea-of-Cortez-Private-Liveaboard.jpeg?rlkey=79ci5evs5yqkbyejlyzmm2l85&raw=1" alt="Sea of Cortez Private Liveaboard" />
     </figure>
     <article class="exp-block">
       <h2>Overview</h2>
@@ -171,7 +171,7 @@
   </section>
 </main>
 <a href="https://wa.me/526242104724" class="whatsapp-button" target="_blank" aria-label="Chat on WhatsApp">
-  <img src="https://www.svgrepo.com/show/303280/whatsapp-glyph-black-logo.svg" alt="WhatsApp" style="width:2rem;height:2rem;display:block;" />
+  <img loading="lazy" src="https://www.svgrepo.com/show/303280/whatsapp-glyph-black-logo.svg" alt="WhatsApp" style="width:2rem;height:2rem;display:block;" />
 </a>
 <script>
 document.addEventListener('scroll',function(){

--- a/expeditions/socorro-island-liveaboard/index.html
+++ b/expeditions/socorro-island-liveaboard/index.html
@@ -122,7 +122,7 @@
       <a class="services__btn" href="https://wa.me/526242104724?text=Hi%20Below%20Surface!%20I%27d%20like%20to%20book%20the%20Socorro%20Island%20Liveaboard" rel="noreferrer" target="_blank">Book</a>
     </div>
     <figure class="exp-img">
-      <img src="https://www.dropbox.com/scl/fi/4ufoln6gfsnusgqom59n1/Socorro-Island.jpeg?rlkey=oyp9po023sbepe8na504rlyux&raw=1" alt="Socorro Island Liveaboard" />
+      <img loading="lazy" src="https://www.dropbox.com/scl/fi/4ufoln6gfsnusgqom59n1/Socorro-Island.jpeg?rlkey=oyp9po023sbepe8na504rlyux&raw=1" alt="Socorro Island Liveaboard" />
     </figure>
     <article class="exp-block">
       <h2>Overview</h2>
@@ -167,7 +167,7 @@
   </section>
 </main>
 <a href="https://wa.me/526242104724" class="whatsapp-button" target="_blank" aria-label="Chat on WhatsApp">
-  <img src="https://www.svgrepo.com/show/303280/whatsapp-glyph-black-logo.svg" alt="WhatsApp" style="width:2rem;height:2rem;display:block;" />
+  <img loading="lazy" src="https://www.svgrepo.com/show/303280/whatsapp-glyph-black-logo.svg" alt="WhatsApp" style="width:2rem;height:2rem;display:block;" />
 </a>
 <script>
 document.addEventListener('scroll',function(){

--- a/expeditions/winter-whales/index.html
+++ b/expeditions/winter-whales/index.html
@@ -122,7 +122,7 @@
       <a class="services__btn" href="https://wa.me/526242104724?text=Hi%20Below%20Surface!%20I%27d%20like%20to%20book%20the%20Winter%20Whales" rel="noreferrer" target="_blank">Book</a>
     </div>
     <figure class="exp-img">
-      <img src="https://www.dropbox.com/scl/fi/k8uv8gk7lg0k3mu03yo7g/WINTER-WHALES.jpg?rlkey=kb19flw7933mnisthy183wxmn&raw=1" alt="Winter Whales" />
+      <img loading="lazy" src="https://www.dropbox.com/scl/fi/k8uv8gk7lg0k3mu03yo7g/WINTER-WHALES.jpg?rlkey=kb19flw7933mnisthy183wxmn&raw=1" alt="Winter Whales" />
     </figure>
     <article class="exp-block">
       <h2>Overview</h2>
@@ -181,7 +181,7 @@
   </section>
 </main>
 <a href="https://wa.me/526242104724" class="whatsapp-button" target="_blank" aria-label="Chat on WhatsApp">
-  <img src="https://www.svgrepo.com/show/303280/whatsapp-glyph-black-logo.svg" alt="WhatsApp" style="width:2rem;height:2rem;display:block;" />
+  <img loading="lazy" src="https://www.svgrepo.com/show/303280/whatsapp-glyph-black-logo.svg" alt="WhatsApp" style="width:2rem;height:2rem;display:block;" />
 </a>
 <script>
 document.addEventListener('scroll',function(){

--- a/index.html
+++ b/index.html
@@ -1167,7 +1167,7 @@
 <section class="about" id="About" aria-label="About Us">
   <div class="about__wrap">
     <figure class="about__media" aria-hidden="true">
-      <img src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Dani%20Tormo.png?raw=true" alt="Dani Tormo">
+      <img loading="lazy" src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Dani%20Tormo.png?raw=true" alt="Dani Tormo">
     </figure>
 
     <article class="about__panel">
@@ -1488,17 +1488,17 @@
 
       <div class="bs-gallery-row" id="bsGalleryRow">
         <!-- ONE STRIPE ONLY — NO REPEATS -->
-        <img src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/About%20Us.jpeg?raw=true" />
-        <img src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Baitball%20&%20Marlin.jpg?raw=true" />
-        <img src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Dani%20Tormo%20Sub.jpg?raw=true" />
-        <img src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Expeditions%20Photo.jpeg?raw=true" />
-        <img src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Grey%20Whale.jpg?raw=true" />
-        <img src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Orcas.jpg?raw=true" />
-        <img src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Sea%20lion.jpg?raw=true" />
-        <img src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Shipwreck%20Turtle.jpg?raw=true" />
-        <img src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Snappers.jpg?raw=true" />
-        <img src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/WINTER%20WHALES.jpg?raw=true" />
-        <img src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/WHALE%20SHARK.jpg?raw=true" />
+        <img loading="lazy" src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/About%20Us.jpeg?raw=true" />
+        <img loading="lazy" src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Baitball%20&%20Marlin.jpg?raw=true" />
+        <img loading="lazy" src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Dani%20Tormo%20Sub.jpg?raw=true" />
+        <img loading="lazy" src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Expeditions%20Photo.jpeg?raw=true" />
+        <img loading="lazy" src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Grey%20Whale.jpg?raw=true" />
+        <img loading="lazy" src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Orcas.jpg?raw=true" />
+        <img loading="lazy" src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Sea%20lion.jpg?raw=true" />
+        <img loading="lazy" src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Shipwreck%20Turtle.jpg?raw=true" />
+        <img loading="lazy" src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Snappers.jpg?raw=true" />
+        <img loading="lazy" src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/WINTER%20WHALES.jpg?raw=true" />
+        <img loading="lazy" src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/WHALE%20SHARK.jpg?raw=true" />
 
       </div>
 
@@ -1525,7 +1525,7 @@
     <button class="bs-close-btn" id="bsCloseLightbox" aria-label="Close Gallery">&times;</button>
     <button class="bs-nav-btn bs-prev-btn" id="bsPrevBtn" aria-label="Previous Image">&#10094;</button>
     <div class="bs-lightbox-img-wrapper">
-      <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" id="bsLightboxImg" alt="Expanded gallery image" draggable="false" />
+      <img loading="lazy" src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" id="bsLightboxImg" alt="Expanded gallery image" draggable="false" />
     </div>
     <button class="bs-nav-btn bs-next-btn" id="bsNextBtn" aria-label="Next Image">&#10095;</button>
   </div>
@@ -2018,6 +2018,7 @@
   aria-label="Chat on WhatsApp"
 >
   <img
+    loading="lazy"
     src="https://www.svgrepo.com/show/303280/whatsapp-glyph-black-logo.svg"
     alt="WhatsApp"
     style="width:2rem;height:2rem;display:block;"


### PR DESCRIPTION
## Summary
- Lazy-load non-critical images across pages for faster rendering
- Defer loading of gallery and hero photos until they enter the viewport

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a05ef6ea148320a55ef4d54aaebc25