### PR TITLE
fix: ensure mobile background images cover page

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1398,3 +1398,12 @@ body.scrolled .elementor-location-header {
     color: var(--highlight);
   }
 }
+
+/* Ensure background images cover on small screens */
+@media (max-width: 768px) {
+  [style*="background-image"] {
+    background-size: cover !important;
+    background-position: center center !important;
+    background-repeat: no-repeat !important;
+  }
+}


### PR DESCRIPTION
## Summary
- force all background images to cover the viewport on small screens

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a05fa4f0f083208975021571e73cf0