### PR TITLE
style: unify page titles

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -13,7 +13,7 @@
 
 <!-- ============ ABOUT (FULL-WIDTH, ONE BACKGROUND, ALTERNATING PANELS, CENTER TITLE) ============ -->
 <section class="about" id="About" aria-label="About Us">
-  <h2 class="about__title">About Us</h2>
+  <h2 class="about__title page-title">About Us</h2>
 
   <div class="about__wrap">
     <div class="about__row reverse">

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -635,13 +635,12 @@ html, body {
     background: url("https://www.dropbox.com/scl/fi/jby8gnjuw2f4woceofvpw/Sharks.jpg?rlkey=fgqpa6ul4fi9uu2l49of66lvp&raw=1") center/cover no-repeat;
 }
 
-.daytrips .services__heading,
-.expeditions .services__heading,
-.charter .services__heading {
+/* Consistent page titles */
+.page-title {
   text-align: center;
   font: 700 clamp(2rem,4vw,3rem)/1.2 inherit;
   color: var(--highlight);
-  margin-bottom: clamp(1rem,2vh,1.5rem);
+  margin: 0 0 clamp(1rem,2vh,1.5rem);
 }
 
 .daytrips .services__desc,
@@ -790,9 +789,7 @@ html, body {
     grid-template-columns: 1fr;
   }
 
-  .daytrips .services__heading,
-  .expeditions .services__heading,
-  .charter .services__heading {
+  .page-title {
     font-size: clamp(1.8rem,8vw,2.4rem);
   }
 }
@@ -1325,7 +1322,6 @@ body.scrolled .elementor-location-header {
 }
 
 .exp-hero{ padding: var(--bs-section-padding) 1rem 0; text-align:center; display:flex; flex-direction:column; align-items:center; }
-.exp-title{ color: var(--highlight); font-weight: 800; font-size: clamp(2rem,4vw,3rem); margin: 0 0 .5rem; }
 .exp-subtitle{ color: #fff; font-size: clamp(1.05rem,2.6vw,1.35rem); margin: 0 auto 1.25rem; max-width: 820px; }
 
 .exp-body{ max-width: 980px; margin: 0 auto; padding: clamp(.5rem,2vw,1rem); display: grid; gap: clamp(1rem,2.8vw,1.75rem); place-items: center; }
@@ -1381,7 +1377,7 @@ body.scrolled .elementor-location-header {
     min-height: calc(100vh - 80px);
     justify-content: center;
   }
-  .exp-title {
+  .page-title {
     font-size: clamp(1.8rem, 3.2vw, 2.4rem);
   }
   .exp-subtitle {
@@ -1393,7 +1389,6 @@ body.scrolled .elementor-location-header {
   .exp-hero {
     padding-top: calc(var(--bs-section-padding) + 2rem);
   }
-  .exp-title,
   .exp-subtitle {
     color: var(--highlight);
   }

--- a/charter/index.html
+++ b/charter/index.html
@@ -10,7 +10,7 @@
 <body>
 
 <section class="charter section" id="charter" aria-label="Charter">
-  <h2 class="services__heading">Charter</h2>
+  <h2 class="page-title">Charter</h2>
   <p class="services__desc" style="max-width:600px; margin:0 auto 3rem; text-align:center; font-size:clamp(1.1rem,2vw,1.4rem); color:var(--text-light);">
     Choose from our adventure-ready boats.
   </p>

--- a/day-trips/index.html
+++ b/day-trips/index.html
@@ -10,7 +10,7 @@
 <body>
 
 <section class="daytrips section" id="day-trips" aria-label="Day Trips">
-  <h2 class="services__heading">Day Trips</h2>
+  <h2 class="page-title">Day Trips</h2>
   <p class="services__desc" style="max-width:600px; margin:0 auto 3rem; text-align:center; font-size:clamp(1.1rem,2vw,1.4rem); color:var(--text-light);">
    Discover our handpicked day‑trip adventures—dive, snorkel, and explore beneath the waves in unforgettable style.
   </p>

--- a/expeditions/diving-in-the-sea-of-cortez/index.html
+++ b/expeditions/diving-in-the-sea-of-cortez/index.html
@@ -113,7 +113,7 @@
 <a class="back-arrow" href="../" aria-label="Back to Expeditions"></a>
 <main>
   <section class="exp-hero">
-    <h1 class="exp-title">Diving the Sea of Cortez</h1>
+    <h1 class="page-title">Diving the Sea of Cortez</h1>
     <p class="exp-subtitle">Embark on a unique 5-day diving adventure in the majestic Sea of Cortez, a true underwater paradise. This isn’t your average tour—it’s a personalized expedition designed for true ocean lovers looking to connect with nature in its purest form. Come experience the magic of the ‘Aquarium of the World’ as only 7+ years of local experience can show you!</p>
   </section>
 

--- a/expeditions/index.html
+++ b/expeditions/index.html
@@ -10,7 +10,7 @@
 <body>
 
 <section class="expeditions section" id="expeditions" aria-label="Expeditions">
-  <h2 class="services__heading">Expeditions</h2>
+  <h2 class="page-title">Expeditions</h2>
   <p class="services__desc" style="max-width:600px; margin:0 auto 3rem; text-align:center; font-size:clamp(1.1rem,2vw,1.4rem); color:var(--text-light);">
    Our expeditions are fully customizable to cover all your needs
   </p>

--- a/expeditions/medical-sardine-run/index.html
+++ b/expeditions/medical-sardine-run/index.html
@@ -113,7 +113,7 @@
 <a class="back-arrow" href="../" aria-label="Back to Expeditions"></a>
 <main>
   <section class="exp-hero">
-    <h1 class="exp-title">Mexican Sardine Run Expedition</h1>
+    <h1 class="page-title">Mexican Sardine Run Expedition</h1>
     <p class="exp-subtitle">When baitball season kicks in along the Mexican Pacific, it’s raw, powerful, and beautiful. Swim alongside baitballs with hunting marlins, mahimahi, sea lions, and many more surprises.</p>
   </section>
 

--- a/expeditions/mobulas-and-cetaceans/index.html
+++ b/expeditions/mobulas-and-cetaceans/index.html
@@ -113,7 +113,7 @@
 <a class="back-arrow" href="../" aria-label="Back to Expeditions"></a>
 <main>
   <section class="exp-hero">
-    <h1 class="exp-title">Mobulas & Cetaceans Expedition</h1>
+    <h1 class="page-title">Mobulas & Cetaceans Expedition</h1>
     <p class="exp-subtitle">This summer expedition is one of our favorites! As the warmth arrives in La Ventana, thousands of mobula rays aggregate in these waters. We head out early to find them, with chances for dolphins, whales, or orcas. In this ocean safari, expect the unexpected!</p>
   </section>
 

--- a/expeditions/sea-of-cortez-private-liveaboard/index.html
+++ b/expeditions/sea-of-cortez-private-liveaboard/index.html
@@ -113,7 +113,7 @@
 <a class="back-arrow" href="../" aria-label="Back to Expeditions"></a>
 <main>
   <section class="exp-hero">
-    <h1 class="exp-title">Sea of Cortez Private Liveaboard</h1>
+    <h1 class="page-title">Sea of Cortez Private Liveaboard</h1>
     <p class="exp-subtitle">Explore vibrant reefs, swim with sea lions, and dive crystal-clear waters—privately, with your group only. Fully tailored route, meals, and rhythm.</p>
   </section>
 

--- a/expeditions/socorro-island-liveaboard/index.html
+++ b/expeditions/socorro-island-liveaboard/index.html
@@ -113,7 +113,7 @@
 <a class="back-arrow" href="../" aria-label="Back to Expeditions"></a>
 <main>
   <section class="exp-hero">
-    <h1 class="exp-title">Socorro Island Liveaboard</h1>
+    <h1 class="page-title">Socorro Island Liveaboard</h1>
     <p class="exp-subtitle">Mexico’s most thrilling dive destination: giant mantas, schooling sharks, playful dolphins—remote, pristine, and unforgettable.</p>
   </section>
 

--- a/expeditions/winter-whales/index.html
+++ b/expeditions/winter-whales/index.html
@@ -113,7 +113,7 @@
 <a class="back-arrow" href="../" aria-label="Back to Expeditions"></a>
 <main>
   <section class="exp-hero">
-    <h1 class="exp-title">Winter Whales</h1>
+    <h1 class="page-title">Winter Whales</h1>
     <p class="exp-subtitle">Each winter, the Pacific and the Sea of Cortez host gray, humpback, and blue whales. Hear their songs, watch flukes lift over the horizon, and feel a deep connection to the ocean—this is Baja at its most profound.</p>
   </section>
 


### PR DESCRIPTION
## Summary
- Introduce a shared `.page-title` style for consistent yellow headings across the site
- Apply the new heading class to all pages and expedition subpages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a05f38c6e8832086fcbf80af32194c