### PR TITLE
Align service cards left and improve mobile layout

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -717,10 +717,10 @@ html, body {
   min-height: 200px;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
   gap: 1rem;
-  text-align: center;
+  text-align: left;
   transition: background .3s ease, box-shadow .3s ease, filter .3s ease;
 }
 
@@ -731,6 +731,7 @@ html, body {
   font-size: clamp(1.4rem,2.5vw,1.8rem);
   font-weight: 700;
   color: #fff;
+  text-align: left;
 }
 
 .daytrips .services__text,
@@ -741,13 +742,14 @@ html, body {
   line-height: 1.5;
   color: #fff;
   max-height: 3.3em;
+  text-align: left;
 }
 
 .daytrips .services__btn,
 .expeditions .services__btn,
 .charter .services__btn,
 .exp-cta .services__btn {
-  align-self: center;
+  align-self: flex-start;
   background: var(--highlight);
   color: var(--ink);
   padding: .75rem 1.5rem;
@@ -1031,7 +1033,18 @@ body.scrolled .elementor-location-header {
     grid-template-columns: 1fr;
     gap: 1.5rem;
   }
-  
+
+  .services__card {
+    max-width: none !important;
+  }
+
+  .services__grid:has(.services__card:nth-child(7):last-child) .services__card:nth-child(7),
+  .services__card:nth-child(7):last-child {
+    grid-column: 1;
+    justify-self: stretch;
+    max-width: none;
+  }
+
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
## Summary
- Left-align service card titles, descriptions, and buttons across Day Trips, Expeditions, and Charter pages
- Expand cards to full width on mobile and ensure grids collapse to a single column
- Fix seventh card layout so single-column mobile grids render one card per row

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0628d14a883209924039ae677cd88