### PR TITLE
Use Sea Lion Snorkel image for day trips background

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -637,6 +637,9 @@ html, body {
   padding: clamp(4rem,10vh,6rem) clamp(2rem,6vw,6rem);
   isolation: isolate;
 }
+.daytrips.section {
+  background: url("https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Sealion%20Snorkel.jpeg?raw=true") center center/cover no-repeat;
+}
 .expeditions.section {
     background: url("https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Expeditions%20Photo.jpeg?raw=true") center center/cover no-repeat;
 }


### PR DESCRIPTION
## Summary
- Set Day Trips section background to the Sea Lion Snorkel card photo so desktop and mobile share the same image

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a063b755408320bcbb9e18f4680f46