### PR TITLE
Fix Day Trips background scaling on mobile

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1298,6 +1298,9 @@ body.scrolled .elementor-location-header {
 
 /* ===== DAY TRIPS: MOBILE LAYOUT MATCHING EXPEDITIONS ===== */
 @media (max-width: 768px) {
+  .daytrips.section {
+    min-height: 100vh;
+  }
   .daytrips .services__grid {
     grid-template-columns: 1fr !important;
     gap: 1.5rem !important;


### PR DESCRIPTION
## Summary
- prevent mobile Day Trips hero image from appearing zoomed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a06567811883208b7f8039cde0f2d7