### PR TITLE
Fix mobile expedition hero background scaling

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1401,6 +1401,9 @@ body.scrolled .elementor-location-header {
 @media (max-width: 768px) {
   .exp-hero {
     padding-top: calc(var(--bs-section-padding) + 2rem);
+    min-height: 100vh;
+    background-size: cover;
+    background-position: center;
   }
   .exp-subtitle {
     color: #fff;


### PR DESCRIPTION
## Summary
- Ensure expedition hero section fills the viewport on mobile and centers background image

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a06574faa48320ab93cf5b489e38f8