### PR TITLE
Align mobile service cards across sections

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1392,12 +1392,16 @@ body.scrolled .elementor-location-header {
 @media (max-width: 768px){
   .exp-body{ grid-template-columns: 1fr; }
 }
-/* Day Trips — force 1 card per row on mobile/tablet */
+/* Day Trips, Expeditions & Charter — force 1 card per row on mobile/tablet */
 @media (max-width: 980px){
   /* hit the grid no matter what parent classes are present */
   .services__grid,
   .daytrips .services__grid,
-  body.page-day-trips .services__grid {
+  .expeditions .services__grid,
+  .charter .services__grid,
+  body.page-day-trips .services__grid,
+  body.page-expeditions .services__grid,
+  body.page-charter .services__grid {
     grid-template-columns: 1fr !important;
     justify-items: center !important;
     gap: 1.25rem !important;
@@ -1405,7 +1409,11 @@ body.scrolled .elementor-location-header {
 
   .services__card,
   .daytrips .services__card,
-  body.page-day-trips .services__card {
+  .expeditions .services__card,
+  .charter .services__card,
+  body.page-day-trips .services__card,
+  body.page-expeditions .services__card,
+  body.page-charter .services__card {
     width: 100% !important;
     max-width: 560px !important;
     margin: 0 auto !important;


### PR DESCRIPTION
## Summary
- ensure expedition and charter pages use same mobile service card layout as day trips by expanding CSS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0680915d48320a2716bafb39d7da5