### PR TITLE
Align mobile padding for expedition titles

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1445,6 +1445,12 @@ body.scrolled .elementor-location-header {
   .exp-subtitle {
     color: #fff;
   }
+  .exp-hero .page-title,
+  .exp-hero .exp-subtitle {
+    width: 100%;
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
 }
 
 /* Ensure background images cover on small screens */


### PR DESCRIPTION
## Summary
- Ensure expedition hero titles and subtitles share equal left/right padding on mobile screens

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a06af12b7083208765f8924ca113c9