### PR TITLE
Use Dani Tormo Sub photo for mobile About background

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -270,7 +270,7 @@ html, body {
         rgba(0,0,0,0.55) 60%,
         rgba(0,0,0,0.65)
       ),
-      url("https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/About-Us-Mobile.jpg?raw=true")
+      url("https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Dani%20Tormo%20Sub.jpg?raw=true")
         top center / contain no-repeat;
     min-height: 100vh;
   }


### PR DESCRIPTION
## Summary
- update mobile About section background to use Dani Tormo Sub image

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a06d414d2483209dc42711e6cb8025