### PR TITLE
Add parallax mobile background for About page

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -271,7 +271,8 @@ html, body {
         rgba(0,0,0,0.65)
       ),
       url("https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/About-Us-Mobile.jpg?raw=true")
-        top center / contain no-repeat;
+        top center/cover no-repeat;
+    background-attachment: scroll, fixed;
     min-height: 100vh;
   }
 }


### PR DESCRIPTION
## Summary
- Make About page background parallax on mobile
- Ensure mobile background photo covers the full screen

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a06da005588320ae9bd272288b723e