### PR TITLE
Reduce hero section headline size on desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,7 +181,7 @@
       transform: translate(-50%, -50%);
       width: min(1000px, 92vw);
       margin: 0;
-      font: 700 clamp(1.2rem, 1.6vw + 1rem, 2.2rem) / 1.25 inherit;
+      font: 700 clamp(1.2rem, 1.2vw + 1rem, 1.8rem) / 1.25 inherit;
       color: var(--bs-primary);
       opacity: 0;
       text-align: center;


### PR DESCRIPTION
## Summary
- Shrink rotating hero headlines for desktop view by reducing their maximum font size.

## Testing
- `npx --yes htmlhint index.html`

------
https://chatgpt.com/codex/tasks/task_e_68a06f5c581c83208dcef1f8643d3d95