### PR TITLE
feat: add top padding to section titles

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -695,6 +695,12 @@ html, body {
   margin: 0 0 clamp(1rem,2vh,1.5rem);
 }
 
+.daytrips .page-title,
+.expeditions .page-title,
+.charter .page-title {
+  padding-top: clamp(2rem, 8vh, 3rem);
+}
+
 .daytrips .services__desc,
 .expeditions .services__desc,
 .charter .services__desc {


### PR DESCRIPTION
## Summary
- add top padding before the titles on Expeditions, Day Trips, and Charter pages

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a07ae9738c8320a0a59596e783486a