### PR TITLE
Reduce mobile spacing around subpage titles

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -683,7 +683,7 @@ html, body {
   .daytrips.section,
   .expeditions.section,
   .charter.section {
-    padding: clamp(2rem,6vh,3rem) clamp(1rem,4vw,2rem);
+    padding: clamp(1rem,4vh,2rem) clamp(1rem,4vw,2rem);
   }
 }
 
@@ -710,7 +710,7 @@ html, body {
   .daytrips .services__desc,
   .expeditions .services__desc,
   .charter .services__desc {
-    margin-bottom: clamp(1rem,3vh,1.5rem);
+    margin-bottom: clamp(.5rem,2vh,1rem);
   }
 }
 
@@ -1179,6 +1179,16 @@ body.scrolled .elementor-location-header {
 .about__title {
   margin: 0; /* remove extra margin */
   padding: clamp(1.5rem, 5vh, 2.5rem) 0;
+}
+
+@media (max-width: 768px) {
+  .about {
+    padding: clamp(1rem,4vh,2rem) clamp(1rem,4vw,2rem);
+  }
+
+  .about__title {
+    padding: clamp(1rem,3vh,1.5rem) 0;
+  }
 }
 /* About page layout */
 .about__wrap {


### PR DESCRIPTION
## Summary
- Trimmed top/bottom padding for Day Trips, Expeditions and Charter sections on mobile
- Tightened spacing under section descriptions for cleaner mobile layout
- Added mobile-specific padding rules for About section and title

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a07b14c6288320a0370cb5be76790e