### PR TITLE
Add global footer with contact info

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1532,3 +1532,25 @@ h1 { font-size: clamp(3rem, 6vw, 4rem); }
 h2 { font-size: clamp(2.5rem, 5vw, 3.5rem); }
 h3 { font-size: clamp(2rem, 4vw, 3rem); }
 
+/* Site Footer */
+.site-footer {
+  background: var(--bg-dark);
+  color: var(--highlight);
+  text-align: center;
+  padding: 2rem 1rem;
+  font-size: 0.875rem;
+}
+.site-footer a {
+  color: var(--highlight);
+  text-decoration: none;
+}
+.site-footer a:hover,
+.site-footer a:focus {
+  text-decoration: underline;
+}
+.site-footer .footer__content {
+  margin-bottom: 0.5rem;
+}
+.site-footer .separator {
+  margin: 0 0.5rem;
+}

--- a/assets/js/dropbox.js
+++ b/assets/js/dropbox.js
@@ -85,3 +85,20 @@
   });
 })();
 
+
+document.addEventListener('DOMContentLoaded', function () {
+  const footer = document.createElement('footer');
+  footer.className = 'site-footer';
+  const year = new Date().getFullYear();
+  footer.innerHTML = `
+    <div class="footer__content">
+      <a href="mailto:dani@bajabelowsurface.com">dani@bajabelowsurface.com</a>
+      <span class="separator">•</span>
+      <a href="https://wa.me/526242104724" target="_blank" rel="noopener">+52 624 210 4724</a>
+      <span class="separator">•</span>
+      <a href="https://instagram.com/bajabelowsurface" target="_blank" rel="noopener">@bajabelowsurface</a>
+    </div>
+    <p class="footer__copy">&copy; ${year} Below Surface</p>
+  `;
+  document.body.appendChild(footer);
+});


### PR DESCRIPTION
## Summary
- inject site-wide footer via existing JavaScript bundle
- style footer with dark blue background and yellow text

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a07b5de2a48320bcf1a3d92fecf2d1