### PR TITLE
Add privacy policy page

### DIFF
--- a/index.html
+++ b/index.html
@@ -2235,6 +2235,7 @@ document.addEventListener('scroll',function(){
         <li role="none"><a class="menu__link" role="menuitem" href="https://nicomalgeri.github.io/baja-below-surface/expeditions" style="--delay:.16s">Expeditions</a></li>
         <li role="none"><a class="menu__link" role="menuitem" href="https://nicomalgeri.github.io/baja-below-surface/charter" style="--delay:.24s">Charter</a></li>
         <li role="none"><a class="menu__link" role="menuitem" href="https://nicomalgeri.github.io/baja-below-surface/about-us" style="--delay:.32s">About Us</a></li>
+        <li role="none"><a class="menu__link" role="menuitem" href="https://nicomalgeri.github.io/baja-below-surface/privacy-policy" style="--delay:.40s">Privacy Policy</a></li>
       </ul>
     </div>
 

--- a/privacy-policy/index.html
+++ b/privacy-policy/index.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Privacy Policy – Below Surface</title>
+  <meta name="description" content="Privacy Policy" />
+  <link rel="stylesheet" href="../assets/css/main.css" />
+</head>
+<body>
+
+<section class="privacy section" id="privacy-policy" aria-label="Privacy Policy">
+  <h2 class="page-title">Privacy Policy</h2>
+  <p class="services__desc" style="max-width:800px; margin:0 auto 3rem; text-align:center; font-size:clamp(1.1rem,2vw,1.4rem); color:var(--text-light);">
+    Your privacy is important to us. This policy explains what information we collect and how we use it.
+  </p>
+
+  <div class="policy__content" style="max-width:800px; margin:0 auto; font-size:clamp(1rem,2vw,1.1rem); line-height:1.6; color:var(--text-light);">
+    <h3>Information We Collect</h3>
+    <p>We only collect personal information that you voluntarily provide, such as your name, email address, and any details included in messages you send us.</p>
+
+    <h3>How We Use Information</h3>
+    <p>The information we collect is used to respond to inquiries, deliver services you request, and improve our website.</p>
+
+    <h3>Cookies</h3>
+    <p>Our website may use cookies to remember your preferences and analyze site traffic. You can control cookies through your browser settings.</p>
+
+    <h3>Third-Party Services</h3>
+    <p>We may utilize third-party tools, such as analytics or social media plugins, that collect data according to their own privacy policies.</p>
+
+    <h3>Data Security</h3>
+    <p>We implement reasonable security measures to protect your information, but no method of transmission over the internet is completely secure.</p>
+
+    <h3>Your Choices</h3>
+    <p>You may request access to or deletion of your personal information by contacting us.</p>
+
+    <h3>Contact Us</h3>
+    <p>If you have any questions about this policy, please contact us at <a href="mailto:dani@bajabelowsurface.com">dani@bajabelowsurface.com</a>.</p>
+
+    <p>Last updated: 16 August 2025.</p>
+  </div>
+</section>
+
+<header class="bs-header">
+  <button class="ham" id="ham" aria-label="Open menu" aria-controls="menu" aria-expanded="false">
+    <span class="ham__icon" aria-hidden="true">
+      <span class="ham__bar ham__bar--1"></span>
+      <span class="ham__bar ham__bar--2"></span>
+      <span class="ham__bar ham__bar--3"></span>
+    </span>
+    <span class="ham__text"></span>
+  </button>
+  <a class="bs-logo" href="https://nicomalgeri.github.io/baja-below-surface/">
+    <img src="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/logo1-scaled.png?raw=true" alt="Baja Below Surface logo">
+  </a>
+</header>
+
+<!-- Fullscreen Menu -->
+<nav class="menu" id="menu" aria-hidden="true">
+  <div class="menu__container">
+    <!-- CENTERED TITLES AREA -->
+    <div class="menu__center">
+      <ul class="menu__list" role="menu" aria-label="Main menu">
+        <li role="none"><a class="menu__link" role="menuitem" href="https://nicomalgeri.github.io/baja-below-surface/" style="--delay:.00s">Home</a></li>
+        <li role="none"><a class="menu__link" role="menuitem" href="https://nicomalgeri.github.io/baja-below-surface/day-trips" style="--delay:.08s">Day Trips</a></li>
+        <li role="none"><a class="menu__link" role="menuitem" href="https://nicomalgeri.github.io/baja-below-surface/expeditions" style="--delay:.16s">Expeditions</a></li>
+        <li role="none"><a class="menu__link" role="menuitem" href="https://nicomalgeri.github.io/baja-below-surface/charter" style="--delay:.24s">Charter</a></li>
+        <li role="none"><a class="menu__link" role="menuitem" href="https://nicomalgeri.github.io/baja-below-surface/about-us" style="--delay:.32s">About Us</a></li>
+        <li role="none"><a class="menu__link" role="menuitem" href="https://nicomalgeri.github.io/baja-below-surface/privacy-policy" style="--delay:.40s">Privacy Policy</a></li>
+      </ul>
+    </div>
+
+    <!-- SOCIALS AT BOTTOM -->
+    <div class="mini-icons">
+      <div class="mini-pair">
+        <a class="mini-icon" href="https://instagram.com/bajabelowsurface" aria-label="Instagram" target="_blank" rel="noopener">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" role="img" aria-hidden="true">
+            <rect x="3" y="3" width="18" height="18" rx="5" ry="5"></rect>
+            <circle cx="12" cy="12" r="4"></circle>
+            <circle cx="17.5" cy="6.5" r="1"></circle>
+          </svg>
+        </a>
+        <a class="contact__icon-text" href="https://instagram.com/bajabelowsurface" target="_blank" rel="noopener">@bajabelowsurface</a>
+      </div>
+      <div class="mini-pair">
+        <a class="mini-icon" href="mailto:dani@bajabelowsurface.com" aria-label="Email">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" role="img" aria-hidden="true">
+            <rect x="3" y="5" width="18" height="14" rx="2" ry="2"></rect>
+            <path d="M3 7l9 6 9-6"></path>
+          </svg>
+        </a>
+        <a class="contact__icon-text" href="mailto:dani@bajabelowsurface.com">dani@bajabelowsurface.com</a>
+      </div>
+    </div>
+  </div>
+</nav>
+
+<script>
+(function(){
+  const btn = document.getElementById('ham');
+  const menu = document.getElementById('menu');
+  const links = menu.querySelectorAll('.menu__link');
+  const hamText = btn.querySelector('.ham__text');
+  let lastFocus = null;
+
+  // Ensure ONLY one active link
+  const norm = (u)=>{ try{ const x=new URL(u, location.origin); return (x.origin+x.pathname+x.search).replace(/\/+$/,''); } catch(e){ return u; } };
+  const here = norm(location.href);
+  links.forEach(l => { l.classList.remove('is-active'); l.removeAttribute('aria-current'); });
+  links.forEach(a => {
+    if (norm(a.href) === here) {
+      a.classList.add('is-active');
+      a.setAttribute('aria-current','page');
+      if(hamText) hamText.textContent = a.textContent.trim();
+    }
+  });
+
+  const lock = (on)=>{ document.documentElement.style.overflow = on ? 'hidden' : ''; };
+
+  function openMenu(){
+    lastFocus = document.activeElement;
+    btn.setAttribute('aria-expanded','true');
+    menu.classList.add('is-open');
+    menu.removeAttribute('aria-hidden');
+    lock(true);
+    document.addEventListener('click', onAnyClick);
+    document.addEventListener('keydown', onKey);
+  }
+  function closeMenu(){
+    btn.setAttribute('aria-expanded','false');
+    menu.classList.remove('is-open');
+    menu.setAttribute('aria-hidden','true');
+    lock(false);
+    document.removeEventListener('click', onAnyClick);
+    document.removeEventListener('keydown', onKey);
+    if(lastFocus) lastFocus.focus();
+  }
+  function toggle(){ btn.getAttribute('aria-expanded')==='true' ? closeMenu() : openMenu(); }
+
+  function onAnyClick(e){
+    if (e.target===btn || btn.contains(e.target)) return;
+    if (!menu.contains(e.target)) closeMenu();
+  }
+  function onKey(e){ if(e.key==='Escape') closeMenu(); }
+
+  btn.addEventListener('click', e=>{ e.stopPropagation(); toggle(); });
+  links.forEach(a => a.addEventListener('click', closeMenu));
+})();
+</script>
+
+<script src="../assets/js/dropbox.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add dedicated Privacy Policy page using existing site CSS and navigation structure
- Link Privacy Policy in site-wide menu

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a07baec2348320a08945ac2bfb3ace