### PR TITLE
Add cookie policy popup

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -297,6 +297,7 @@
 </script>
 
 <script src="../assets/js/dropbox.js"></script>
+<script src="../assets/js/cookie-consent.js"></script>
 
 </body>
 </html>

--- a/assets/js/cookie-consent.js
+++ b/assets/js/cookie-consent.js
@@ -1,0 +1,63 @@
+(function(){
+  document.addEventListener('DOMContentLoaded', function(){
+    if (localStorage.getItem('cookieConsent')) return;
+
+    const banner = document.createElement('div');
+    banner.className = 'cookie-banner';
+    banner.innerHTML = `
+      <p>We use cookies to improve your experience. Do you accept?</p>
+      <div class="cookie-buttons">
+        <button class="cookie-accept">Accept</button>
+        <button class="cookie-deny">Deny</button>
+      </div>
+    `;
+
+    const style = document.createElement('style');
+    style.textContent = `
+      .cookie-banner {
+        position: fixed;
+        bottom: 1rem;
+        left: 1rem;
+        right: 1rem;
+        padding: 1rem;
+        background: #001a33;
+        color: #ffd700;
+        border-radius: 8px;
+        z-index: 10000;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.5rem;
+        text-align: center;
+        box-shadow: 0 2px 6px rgba(0,0,0,0.4);
+      }
+      .cookie-banner .cookie-buttons {
+        display: flex;
+        gap: 0.5rem;
+      }
+      .cookie-banner button {
+        background: transparent;
+        border: 2px solid #ffd700;
+        color: #ffd700;
+        padding: 0.4rem 0.8rem;
+        border-radius: 4px;
+        cursor: pointer;
+      }
+      .cookie-banner button:hover {
+        background: #ffd700;
+        color: #001a33;
+      }
+    `;
+    document.head.appendChild(style);
+    document.body.appendChild(banner);
+
+    banner.querySelector('.cookie-accept').addEventListener('click', function(){
+      localStorage.setItem('cookieConsent', 'accepted');
+      banner.remove();
+    });
+    banner.querySelector('.cookie-deny').addEventListener('click', function(){
+      localStorage.setItem('cookieConsent', 'denied');
+      banner.remove();
+    });
+  });
+})();

--- a/charter/index.html
+++ b/charter/index.html
@@ -295,6 +295,7 @@
 </script>
 
 <script src="../assets/js/dropbox.js"></script>
+<script src="../assets/js/cookie-consent.js"></script>
 
 </body>
 </html>

--- a/day-trips/index.html
+++ b/day-trips/index.html
@@ -362,6 +362,7 @@
 </script>
 
 <script src="../assets/js/dropbox.js"></script>
+<script src="../assets/js/cookie-consent.js"></script>
 
 </body>
 </html>

--- a/expeditions/index.html
+++ b/expeditions/index.html
@@ -348,6 +348,7 @@
 </script>
 
 <script src="../assets/js/dropbox.js"></script>
+<script src="../assets/js/cookie-consent.js"></script>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -2318,5 +2318,6 @@ document.addEventListener('scroll',function(){
 })();
 </script>
 <script src="assets/js/dropbox.js"></script>
+<script src="assets/js/cookie-consent.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add reusable cookie-consent script with dark-blue background and yellow text
- load cookie-consent script on all pages so visitors can accept or deny cookies on first visit

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a07be284bc83209e3e6a30e4fe83f6