### PR TITLE
Fix gallery card visibility in gallery section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1586,7 +1586,7 @@
           <h1 class="bs-gallery-title">Gallery</h1>
           <div class="bs-gallery-content">
             <article
-              class="bs-service-card bs-gallery-card bs-loading"
+              class="bs-service-card bs-gallery-card bs-loaded"
               id="bsGalleryCard"
               style="--delay: 1.35s;"
               role="listitem"
@@ -1623,6 +1623,7 @@
         </section>
         </div>
 
+  <script>
   /* ===== Lightbox ===== */
   const lightbox = document.getElementById('bsLightbox');
   const lightboxImg = document.getElementById('bsLightboxImg');


### PR DESCRIPTION
## Summary
- ensure gallery card is visible by default
- restore missing script tag for gallery lightbox logic

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `tidy -qe index.html` *(warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a07e3bc84883208a73c346fbab0a7d