### PR TITLE
feat: enhance cookie consent banner

### DIFF
--- a/assets/js/cookie-consent.js
+++ b/assets/js/cookie-consent.js
@@ -5,9 +5,10 @@
     const banner = document.createElement('div');
     banner.className = 'cookie-banner';
     banner.innerHTML = `
-      <p>We use cookies to improve your experience. Do you accept?</p>
+      <h2>This website uses cookies</h2>
+      <p>We use cookies to personalise content and ads, to provide social media features and to analyse our traffic. We also share information about your use of our site with our social media, advertising and analytics partners who may combine it with other information that you’ve provided to them or that they’ve collected from your use of their services.</p>
       <div class="cookie-buttons">
-        <button class="cookie-accept">Accept</button>
+        <button class="cookie-accept">Allow</button>
         <button class="cookie-deny">Deny</button>
       </div>
     `;
@@ -19,17 +20,23 @@
         bottom: 1rem;
         left: 1rem;
         right: 1rem;
-        padding: 1rem;
+        padding: 1.5rem;
         background: #001a33;
         color: #ffd700;
-        border-radius: 8px;
+        border-radius: 12px;
         z-index: 10000;
         display: flex;
         flex-direction: column;
         align-items: center;
-        gap: 0.5rem;
+        gap: 0.75rem;
         text-align: center;
-        box-shadow: 0 2px 6px rgba(0,0,0,0.4);
+        box-shadow: 0 4px 12px rgba(0,0,0,0.4);
+        font-size: 1.1rem;
+        animation: float 3s ease-in-out infinite alternate;
+      }
+      .cookie-banner h2 {
+        margin: 0;
+        font-size: 1.4rem;
       }
       .cookie-banner .cookie-buttons {
         display: flex;
@@ -39,13 +46,17 @@
         background: transparent;
         border: 2px solid #ffd700;
         color: #ffd700;
-        padding: 0.4rem 0.8rem;
-        border-radius: 4px;
+        padding: 0.5rem 1rem;
+        border-radius: 6px;
         cursor: pointer;
       }
       .cookie-banner button:hover {
         background: #ffd700;
         color: #001a33;
+      }
+      @keyframes float {
+        from { transform: translateY(0); }
+        to { transform: translateY(-10px); }
       }
     `;
     document.head.appendChild(style);


### PR DESCRIPTION
## Summary
- redesign cookie consent banner with larger text and new messaging
- add floating animation, rounded corners and allow/deny buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a07f557d9c83208820a12d81bd8ae6