### PR TITLE
Improve mobile padding before page titles

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -699,8 +699,18 @@ html, body {
 
 .daytrips .page-title,
 .expeditions .page-title,
-.charter .page-title {
+.charter .page-title,
+.about .page-title {
   padding-top: clamp(2rem, 8vh, 3rem);
+}
+
+@media (max-width: 768px) {
+  .daytrips .page-title,
+  .expeditions .page-title,
+  .charter .page-title,
+  .about .page-title {
+    padding-top: clamp(4rem, 12vh, 6rem);
+  }
 }
 
 .daytrips .services__desc,


### PR DESCRIPTION
## Summary
- add about page to page-title spacing rules
- increase top padding for page titles on small screens

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a08b0235cc8320be71ca8cebf22d55