### PR TITLE
Update About Us background image

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -255,7 +255,7 @@ html, body {
       rgba(0,0,0,0.55) 60%,
       rgba(0,0,0,0.65)
     ),
-    url("https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Socorro%20Island.jpeg?raw=true") center bottom / cover no-repeat;
+    url("https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Baitball%20%26%20Marlin.jpg?raw=true") center center / cover no-repeat;
   background-attachment: scroll, fixed;
   min-height: 100vh;
   color: #fff;
@@ -272,8 +272,7 @@ html, body {
         rgba(0,0,0,0.55) 60%,
         rgba(0,0,0,0.65)
       ),
-      url("https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/About-Us-Mobile.jpg?raw=true")
-        top center/cover no-repeat;
+      url("https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Baitball%20%26%20Marlin.jpg?raw=true") center center/cover no-repeat;
     background-attachment: scroll, fixed;
     min-height: 100vh;
     padding: clamp(2rem,6vh,3rem) 1.5rem;


### PR DESCRIPTION
## Summary
- Replace About Us section background with Baitball & Marlin image from repo
- Ensure background positioning covers full section on desktop and mobile

## Testing
- `npx prettier@3.1.1 --check "assets/css/main.css" "about-us/index.html"` *(fails: Code style issues found in 2 files)*

------
https://chatgpt.com/codex/tasks/task_e_68a08c6b49e48320816895efff17b041