### PR TITLE
Add About Us styling to privacy policy page

### DIFF
--- a/privacy-policy/index.html
+++ b/privacy-policy/index.html
@@ -41,6 +41,147 @@
   </div>
 </section>
 
+<!-- WhatsApp Floating Button -->
+<a
+  href="https://wa.me/526242104724"
+  class="whatsapp-button"
+  target="_blank"
+  aria-label="Chat on WhatsApp">
+  <img
+    loading="lazy"
+    src="https://www.svgrepo.com/show/303280/whatsapp-glyph-black-logo.svg"
+    alt="WhatsApp"
+    style="width:2rem;height:2rem;display:block;" />
+</a>
+
+<!-- ===== Hamburger Menu (RESPONSIVE: titles perfectly centered; socials pinned bottom. Desktop keeps extra top padding.) ===== -->
+<style>
+  :root{
+    --accent:#f6e7b0;     /* yellow tone */
+    --ink:#21262d;        /* blue/ink tone */
+    --overlay:rgba(10,14,18,.88);
+    --glass:blur(14px) saturate(1.2);
+    --z:99999;
+  }
+
+  /* Sticky header with translucent blur */
+  .bs-header{
+    position:fixed; top:0; left:0; width:100%;
+    display:flex; justify-content:center; align-items:center;
+    padding:clamp(6px,1.5vh,12px) clamp(10px,2vw,18px);
+    background:rgba(13,24,30,.35);
+    -webkit-backdrop-filter:blur(14px);
+    backdrop-filter:blur(14px);
+    z-index:var(--z);
+  }
+  .bs-logo{ width:48px; height:48px; display:block; }
+  .bs-logo img{ width:100%; height:100%; object-fit:contain; display:block; }
+
+  /* Hamburger: yellow lines only, no hover bg */
+  .ham{
+    position:absolute; left:clamp(10px,2vw,18px); top:50%; transform:translateY(-50%);
+    width:48px; height:48px; border:0; background:transparent; padding:0; cursor:pointer;
+    display:grid; place-items:center; border-radius:12px;
+  }
+  .ham:hover, .ham:focus, .ham:focus-visible{ background:transparent; box-shadow:none; outline:none; }
+  .ham__icon{ width:24px; height:18px; position:relative; }
+  .ham__text{
+    position:absolute; top:50%; left:100%; margin-left:8px;
+    transform:translateY(-50%);
+    color:var(--accent); font-weight:700; white-space:nowrap;
+    opacity:0; transition:opacity .2s ease;
+    pointer-events:none;
+  }
+  .ham:hover .ham__text,
+  .ham[aria-expanded="true"] .ham__text{ opacity:1; }
+  .ham__bar{
+    position:absolute; left:0; right:0; height:2px; background:var(--accent);
+    border-radius:2px; transform-origin:50% 50%;
+    transition:transform .24s ease, opacity .2s ease, top .24s ease, bottom .24s ease;
+  }
+  .ham__bar--1{ top:0; }
+  .ham__bar--2{ top:8px; }
+  .ham__bar--3{ bottom:0; }
+  .ham[aria-expanded="true"] .ham__bar--1{ top:8px; transform:rotate(45deg); }
+  .ham[aria-expanded="true"] .ham__bar--2{ opacity:0; }
+  .ham[aria-expanded="true"] .ham__bar--3{ bottom:auto; top:8px; transform:rotate(-45deg); }
+
+  /* Overlay */
+  .menu{
+    position:fixed; inset:0; display:none; z-index:calc(var(--z) - 1);
+    background:var(--overlay); -webkit-backdrop-filter:var(--glass); backdrop-filter:var(--glass);
+  }
+  .menu.is-open{ display:block; animation:fadeIn .22s ease forwards; }
+  @keyframes fadeIn{ from{opacity:0} to{opacity:1} }
+
+  /* Container: grid layout with titles centered and socials at bottom */
+  .menu__container{
+    height:100%; width:100%;
+    display:grid;
+    grid-template-rows: 1fr auto;     /* row1 = center area, row2 = socials */
+    align-items:stretch; justify-items:center;
+    padding: 0 20px;
+  }
+
+  /* Titles wrapper */
+  .menu__center{
+    grid-row:1;
+    width:100%;
+    display:flex;
+    align-items:center;
+    justify-content:center;  /* TRUE vertical centering */
+    padding:clamp(40px,10vh,100px) 0;
+    box-sizing:border-box;
+  }
+
+  /* Menu list */
+  .menu__list{
+    list-style:none; margin:0; padding:0;
+    display:grid; gap:12px; text-align:center; place-items:center;
+  }
+
+  /* Links with staggered fade-in */
+  .menu__link{
+    display:inline-block; padding:.6rem 1.2rem;
+    border-radius:14px; text-decoration:none; font-weight:800; letter-spacing:.4px;
+    font-size:clamp(1.6rem, 1.4vw + 1rem, 2.2rem);   /* slightly smaller on desktop */
+    color:var(--accent); background:transparent;
+    transition:transform .2s ease, color .2s ease, background .2s ease, box-shadow .2s ease;
+    opacity:0; transform:translateY(10px);
+    animation:rise .4s ease forwards; animation-delay:var(--delay, 0s);
+  }
+  @keyframes rise{ to{ opacity:1; transform:none; } }
+
+  /* Active (only one set in JS) */
+  .menu__link.is-active,
+  .menu__link[aria-current="page"]{ background:var(--accent); color:var(--ink); }
+
+  /* Hover */
+  .menu__link:hover, .menu__link:focus{
+    background:var(--accent); color:var(--ink);
+    transform:translateY(-2px); box-shadow:0 16px 34px -14px rgba(0,0,0,.45); outline:0;
+  }
+
+  /* Socials pinned bottom */
+  .menu .mini-icons{
+    width:100%; display:flex; flex-direction:column; align-items:center; gap:10px;
+    padding: 8px 0 16px;
+  }
+  .mini-pair{ display:flex; align-items:center; gap:10px; white-space:nowrap; }
+  .mini-icon{
+    --size:26px; --pad:8px;
+    display:inline-flex; align-items:center; justify-content:center;
+    width:calc(var(--size) + var(--pad)*2); height:calc(var(--size) + var(--pad)*2);
+    color:var(--accent); background:transparent; border-radius:999px; text-decoration:none;
+    transition:background .2s ease, transform .05s ease; flex-shrink:0;
+  }
+  .mini-icon:hover{ background:var(--accent); color:var(--ink); }
+  .mini-icon svg{ width:var(--size); height:var(--size); display:block; }
+  .contact__icon-text{ color:var(--accent); font-weight:600; font-size:1rem; }
+
+  /* Titles remain centered across all viewport widths */
+</style>
+
 <header class="bs-header">
   <button class="ham" id="ham" aria-label="Open menu" aria-controls="menu" aria-expanded="false">
     <span class="ham__icon" aria-hidden="true">


### PR DESCRIPTION
## Summary
- Add WhatsApp floating button to the privacy policy page
- Copy About Us header and menu CSS to privacy policy page for consistent styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a08cf9a4f48320bd62a5dc3bd7400e