### PR TITLE
fix: show gallery card on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -472,8 +472,17 @@
       gap: 2rem;
     }
     @media (max-width: 768px) {
+      .bs-gallery-preview {
+        padding-top: 2rem;
+        padding-bottom: 2rem;
+      }
       .bs-gallery-content {
         flex-direction: column;
+      }
+      .bs-gallery-content .bs-gallery-card {
+        flex: 0 0 auto;
+        width: 100%;
+        max-width: 360px;
       }
     }
 


### PR DESCRIPTION
## Summary
- ensure gallery preview card is visible on mobile and positioned ahead of video
- add mobile padding to match element gap

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0909ffe448320bbeb40ebb9b5f246