### PR TITLE
Adjust mobile text size for policy pages

### DIFF
--- a/cookies-policy/index.html
+++ b/cookies-policy/index.html
@@ -11,7 +11,7 @@
 
 <section class="cookies-policy" id="cookies-policy" aria-label="Cookies Policy">
   <h2 class="page-title">Cookies Policy</h2>
-  <div class="policy__content" style="max-width:800px;margin:0 auto;padding:0 1rem 2rem;font-size:clamp(1rem,2vw,1.125rem);line-height:1.6;color:var(--text-light);">
+  <div class="policy__content" style="max-width:800px;margin:0 auto;padding:0 1rem 2rem;font-size:clamp(.9rem,2vw,1.125rem);line-height:1.6;color:var(--text-light);">
     <p>Last updated: October 26, 2023</p>
     <p>This Cookies Policy explains what cookies are and how Below Surface uses them on this website.</p>
     <h3>What Are Cookies?</h3>

--- a/privacy-policy/index.html
+++ b/privacy-policy/index.html
@@ -11,11 +11,11 @@
 
 <section class="privacy section" id="privacy-policy" aria-label="Privacy Policy">
   <h2 class="page-title">Privacy Policy</h2>
-  <p class="services__desc" style="max-width:800px; margin:0 auto 3rem; text-align:center; font-size:clamp(1.1rem,2vw,1.4rem); color:var(--text-light);">
+  <p class="services__desc" style="max-width:800px; margin:0 auto 3rem; text-align:center; font-size:clamp(.95rem,2vw,1.4rem); color:var(--text-light);">
     Your privacy is important to us. This policy explains what information we collect and how we use it.
   </p>
 
-  <div class="policy__content" style="max-width:800px; margin:0 auto; font-size:clamp(1rem,2vw,1.1rem); line-height:1.6; color:var(--text-light);">
+  <div class="policy__content" style="max-width:800px; margin:0 auto; font-size:clamp(.9rem,2vw,1.1rem); line-height:1.6; color:var(--text-light);">
     <h3>Information We Collect</h3>
     <p>We only collect personal information that you voluntarily provide, such as your name, email address, and any details included in messages you send us.</p>
 


### PR DESCRIPTION
## Summary
- reduce minimum font size in cookies policy content for improved mobile readability
- lower mobile font size for privacy policy description and content sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a095229e4c8320972730a140afdd5c