### PR TITLE
Extend About Us background to footer

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="../assets/css/main.css" />
 
 </head>
-<body>
+<body class="about-page">
 
 <!-- ============ ABOUT (FULL-WIDTH, ONE BACKGROUND, ALTERNATING PANELS, CENTER TITLE) ============ -->
 <section class="about" id="About" aria-label="About Us">

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -279,6 +279,23 @@ html, body {
   }
 }
 
+/* About Us page: extend background image to full page */
+body.about-page {
+  background:
+    linear-gradient(
+      to bottom,
+      rgba(0,0,0,0.25),
+      rgba(0,0,0,0.55) 60%,
+      rgba(0,0,0,0.65)
+    ),
+    url("https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Baitball%20%26%20Marlin.jpg?raw=true") center center / cover no-repeat;
+  background-attachment: scroll, fixed;
+}
+
+body.about-page .site-footer {
+  background: transparent;
+}
+
 /* ===== GALLERY SECTION ===== */
 .parallax-gallery {
   position: relative;


### PR DESCRIPTION
## Summary
- Ensure About Us page background image spans entire page and footer by applying gradient background to body.
- Make footer transparent so background photo is visible behind it.
- Tag About Us page body with a dedicated class for page-specific styling.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0955f652483209adcfe462b894ec4