### PR TITLE
Reduce hero text size on desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,7 +181,7 @@
       transform: translate(-50%, -50%);
       width: min(1000px, 92vw);
       margin: 0;
-      font: 700 clamp(1.2rem, 1.2vw + 1rem, 1.8rem) / 1.25 inherit;
+      font: 700 clamp(1.1rem, 1vw + 0.5rem, 1.5rem) / 1.25 inherit;
       color: var(--bs-primary);
       opacity: 0;
       text-align: center;


### PR DESCRIPTION
## Summary
- Shrink hero section heading for desktop by tightening clamp values so text that fades in/out is less prominent on large screens.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0988521e4832082da875c289d905a