### PR TITLE
feat: enlarge hero text on desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,7 +181,7 @@
       transform: translate(-50%, -50%);
       width: min(1000px, 92vw);
       margin: 0;
-      font: 700 clamp(1.1rem, 1vw + 0.5rem, 1.5rem) / 1.25 inherit;
+      font: 700 clamp(2rem, 3.5vw + 1rem, 4rem) / 1.25 inherit;
       color: var(--bs-primary);
       opacity: 0;
       text-align: center;
@@ -511,7 +511,7 @@
 
     @media (max-width: 768px) {
       .bs-hero__text {
-        font-size: clamp(1rem, 4.6vw, 1.5rem);
+        font-size: clamp(1.25rem, 5vw + 0.5rem, 2rem);
       }
 
       .bs-hero__scroll {


### PR DESCRIPTION
## Summary
- increase hero headline clamp for larger desktop font sizes
- adjust mobile clamp so text scales smoothly on small screens

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a09a7c4a2083208fad5a222cf6a83b