### PR TITLE
Clean up background images on About Us and Day Trips

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -279,17 +279,9 @@ html, body {
   }
 }
 
-/* About Us page: extend background image to full page */
+/* About Us page base background */
 body.about-page {
-  background:
-    linear-gradient(
-      to bottom,
-      rgba(0,0,0,0.25),
-      rgba(0,0,0,0.55) 60%,
-      rgba(0,0,0,0.65)
-    ),
-    url("https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Baitball%20%26%20Marlin.jpg?raw=true") center center / cover no-repeat;
-  background-attachment: scroll, fixed;
+  background: var(--bg-dark);
 }
 
 body.about-page .site-footer {

--- a/day-trips/index.html
+++ b/day-trips/index.html
@@ -7,7 +7,7 @@
   <meta name="description" content="Day Trips" />
   <link rel="stylesheet" href="../assets/css/main.css" />
 </head>
-<body style="background-color:var(--bg-dark);background-image:url('https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Whale%20Watching.jpeg?raw=true');background-size:cover;background-position:center;background-repeat:no-repeat;">
+<body style="background:var(--bg-dark);">
 
 <section class="daytrips section" id="day-trips" aria-label="Day Trips">
   <h2 class="page-title">Day Trips</h2>


### PR DESCRIPTION
## Summary
- Remove extra body background image from Day Trips page so section image is the sole backdrop
- Drop About page body image and fall back to dark color, leaving the section background as the only photo

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a09e4bc25483208ac10979e7db82e5