### PR TITLE
Replace mobile hero video with Dropbox source

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://bajabelowsurface.com">
   <link rel="preconnect" href="https://www.dropbox.com" crossorigin>
   <link rel="preload" href="https://www.dropbox.com/scl/fi/dwr71773bzfcfvi64rqn8/Main-Video.mov?rlkey=5hmsrj1fjqy86kja6nzlkclok&raw=1" as="video" type="video/mp4" media="(min-width: 768px)" crossorigin="anonymous">
+  <link rel="preload" href="https://www.dropbox.com/scl/fi/1it20errhgmn8ts5rpif1/Main-Video-Mobile.mov?rlkey=ifu73s7nn0xebyzasgofgons6&raw=1" as="video" type="video/mp4" media="(max-width: 767px)" crossorigin="anonymous">
 
   <style>
     /* ========================================
@@ -608,16 +609,21 @@
           <source src="https://www.dropbox.com/scl/fi/dwr71773bzfcfvi64rqn8/Main-Video.mov?rlkey=5hmsrj1fjqy86kja6nzlkclok&raw=1" type="video/mp4" media="(min-width: 768px)">
           <div class="bs-sr-only">Your browser does not support the video tag.</div>
         </video>
-      <iframe
+      <video
         id="bsMainVideoMobile"
         class="bs-hero-video"
-        src="https://www.youtube.com/embed/2WZCaNRrGBI?autoplay=1&mute=1&playsinline=1&controls=0&loop=1&playlist=2WZCaNRrGBI"
-        title="Background video"
-        frameborder="0"
-        allow="autoplay; fullscreen"
-        allowfullscreen
+        autoplay
+        muted
+        loop
+        playsinline
+        preload="auto"
+        aria-hidden="true"
         style="display: none;"
-      ></iframe>
+        crossorigin="anonymous"
+      >
+        <source src="https://www.dropbox.com/scl/fi/1it20errhgmn8ts5rpif1/Main-Video-Mobile.mov?rlkey=ifu73s7nn0xebyzasgofgons6&raw=1" type="video/mp4">
+        <div class="bs-sr-only">Your browser does not support the video tag.</div>
+      </video>
       
       <div class="bs-hero-overlay" aria-hidden="true"></div>
 
@@ -799,8 +805,8 @@
       const VideoManager = {
         init: function() {
           this.video = BSUtils.safeQuery('#bsMainVideo');
-          this.mobileIframe = BSUtils.safeQuery('#bsMainVideoMobile');
-          if (!this.video && !this.mobileIframe) return;
+          this.mobileVideo = BSUtils.safeQuery('#bsMainVideoMobile');
+          if (!this.video && !this.mobileVideo) return;
 
           this.setupResponsiveVideo();
           this.setupVideoErrorHandling();
@@ -822,8 +828,14 @@
               this.video.pause();
               this.video.style.display = 'none';
             }
-            if (this.mobileIframe) {
-              this.mobileIframe.style.display = '';
+            if (this.mobileVideo) {
+              this.mobileVideo.style.display = '';
+              const playPromise = this.mobileVideo.play();
+              if (playPromise !== undefined) {
+                playPromise.catch(error => {
+                  console.warn('BS: Mobile video autoplay failed:', error);
+                });
+              }
               if (wrapper) {
                 wrapper.classList.remove('bs-fallback');
               }
@@ -833,8 +845,9 @@
 
           if (!this.video) return;
 
-          if (this.mobileIframe) {
-            this.mobileIframe.style.display = 'none';
+          if (this.mobileVideo) {
+            this.mobileVideo.pause();
+            this.mobileVideo.style.display = 'none';
           }
           this.video.style.display = 'none';
 


### PR DESCRIPTION
## Summary
- preload new Dropbox-hosted mobile hero video
- use direct mobile `<video>` element instead of YouTube iframe
- auto-play mobile hero video on load via updated VideoManager

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a1f68918832093cb753e77e637c3