### PR TITLE
Swap mobile hero video with optimized source

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <link rel="preconnect" href="https://bajabelowsurface.com">
   <link rel="preconnect" href="https://www.dropbox.com" crossorigin>
   <link rel="preload" href="https://www.dropbox.com/scl/fi/dwr71773bzfcfvi64rqn8/Main-Video.mov?rlkey=5hmsrj1fjqy86kja6nzlkclok&raw=1" as="video" type="video/mp4" media="(min-width: 768px)" crossorigin="anonymous">
-  <link rel="preload" href="https://www.dropbox.com/scl/fi/1it20errhgmn8ts5rpif1/Main-Video-Mobile.mov?rlkey=ifu73s7nn0xebyzasgofgons6&raw=1" as="video" type="video/mp4" media="(max-width: 767px)" crossorigin="anonymous">
+  <link rel="preload" href="https://www.dropbox.com/scl/fi/1it20errhgmn8ts5rpif1/Main-Video-Mobile.mov?rlkey=ifu73s7nn0xebyzasgofgons6&st=bxyn8sza&raw=1" as="video" type="video/mp4" media="(max-width: 767px)" crossorigin="anonymous">
 
   <style>
     /* ========================================
@@ -614,7 +614,7 @@
         style="display: none;"
         crossorigin="anonymous"
       >
-        <source src="https://www.dropbox.com/scl/fi/1it20errhgmn8ts5rpif1/Main-Video-Mobile.mov?rlkey=ifu73s7nn0xebyzasgofgons6&raw=1" type="video/mp4">
+        <source src="https://www.dropbox.com/scl/fi/1it20errhgmn8ts5rpif1/Main-Video-Mobile.mov?rlkey=ifu73s7nn0xebyzasgofgons6&st=bxyn8sza&raw=1" type="video/mp4">
         <div class="bs-sr-only">Your browser does not support the video tag.</div>
       </video>
       
@@ -1641,7 +1641,7 @@
   <div class="bs-video-column">
     <div class="bs-video-wrapper">
       <video id="bsGalleryVideoFull" playsinline preload="metadata" poster="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Desktop%20Static.png?raw=true">
-        <source src="https://www.dropbox.com/scl/fi/1it20errhgmn8ts5rpif1/Main-Video-Mobile.mov?rlkey=ifu73s7nn0xebyzasgofgons6&raw=1" type="video/mp4" media="(max-width: 767px)">
+        <source src="https://www.dropbox.com/scl/fi/1it20errhgmn8ts5rpif1/Main-Video-Mobile.mov?rlkey=ifu73s7nn0xebyzasgofgons6&st=bxyn8sza&raw=1" type="video/mp4" media="(max-width: 767px)">
         <source src="https://www.dropbox.com/scl/fi/dwr71773bzfcfvi64rqn8/Main-Video.mov?rlkey=5hmsrj1fjqy86kja6nzlkclok&raw=1" type="video/mp4" media="(min-width: 768px)">
         Your browser does not support the video tag.
       </video>
@@ -1683,7 +1683,7 @@
             </article>
             <div class="bs-video-wrapper">
               <video id="bsGalleryVideo" playsinline preload="metadata" poster="https://github.com/nicomalgeri/baja-below-surface/blob/main/assets/mediaimages/Desktop%20Static.png?raw=true">
-                <source src="https://www.dropbox.com/scl/fi/1it20errhgmn8ts5rpif1/Main-Video-Mobile.mov?rlkey=ifu73s7nn0xebyzasgofgons6&raw=1" type="video/mp4" media="(max-width: 767px)">
+                <source src="https://www.dropbox.com/scl/fi/1it20errhgmn8ts5rpif1/Main-Video-Mobile.mov?rlkey=ifu73s7nn0xebyzasgofgons6&st=bxyn8sza&raw=1" type="video/mp4" media="(max-width: 767px)">
                 <source src="https://www.dropbox.com/scl/fi/dwr71773bzfcfvi64rqn8/Main-Video.mov?rlkey=5hmsrj1fjqy86kja6nzlkclok&raw=1" type="video/mp4" media="(min-width: 768px)">
                 Your browser does not support the video tag.
               </video>


### PR DESCRIPTION
## Summary
- Swap mobile hero and gallery video sources to new Dropbox URL with st token and raw flag for faster loading

## Testing
- ⚠️ `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a0aa7791988320a2f6aefe2b5e5d96