### PR TITLE
Fix gallery preview duplication and spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -462,36 +462,30 @@
 
     /* Gallery preview layout */
     .bs-gallery-preview {
+      --bs-section-padding: 0.5rem;
       width: 100vw;
       margin-left: calc(50% - 50vw);
       padding: var(--bs-section-padding) 3vw;
       display: flex;
       flex-direction: column;
       align-items: center;
+      gap: 0.5rem;
     }
     .bs-gallery-content {
       display: flex;
       align-items: center;
       justify-content: center;
-      gap: 2rem;
+      gap: 0.5rem;
     }
     @media (max-width: 768px) {
       .bs-gallery-preview {
-        --bs-gallery-gap: 2rem;
-        padding-top: var(--bs-gallery-gap);
-        padding-bottom: var(--bs-gallery-gap);
+        --bs-gallery-gap: 0.5rem;
+        padding: var(--bs-section-padding) 3vw;
         gap: var(--bs-gallery-gap);
-        padding-top: 2rem;
-        padding-bottom: 2rem;
       }
       .bs-gallery-content {
         flex-direction: column;
         gap: var(--bs-gallery-gap);
-      }
-      .bs-gallery-content .bs-gallery-card {
-        flex: 0 0 auto;
-        width: 100%;
-        max-width: 360px;
       }
       .bs-gallery-content .bs-gallery-card {
         flex: 0 0 auto;
@@ -1311,7 +1305,7 @@
       --bs-shadow: 0 22px 48px -18px rgba(0,0,0,.6), 0 6px 16px -6px rgba(0,0,0,.45);
       --bs-row-height: 78vh;
       --bs-thumb-radius: 20px;
-      --bs-gap: 20px;
+      --bs-gap: 8px;
     }
 
     * { box-sizing: border-box; }
@@ -1326,6 +1320,7 @@
     }
 
     .bs-fullscreen-gallery {
+      --bs-section-padding: 0.5rem;
       position: relative;
       width: 100vw;
       margin-left: calc(50% - 50vw);
@@ -1587,11 +1582,11 @@
       .bs-row-wrap { height: 52vh; padding: 0 0.5rem; }
     }
     @media (max-width: 768px) {
-      /* Reduce vertical spacing and keep consistent gaps on mobile */
-      .bs-fullscreen-gallery {
-        --bs-section-padding: 1.5rem;
-        padding: var(--bs-section-padding) 1rem;
-      }
+        /* Reduce vertical spacing and keep consistent gaps on mobile */
+        .bs-fullscreen-gallery {
+          --bs-section-padding: 0.5rem;
+          padding: var(--bs-section-padding) 1rem;
+        }
       .bs-row-wrap { height: 44vh; }
       .bs-close-btn,
       .bs-nav-btn {
@@ -1709,6 +1704,9 @@
   const prevBtn = document.getElementById('bsPrevBtn');
   const nextBtn = document.getElementById('bsNextBtn');
   const galleryImages = document.querySelectorAll('#bsGalleryRow img');
+  const galleryCard = document.getElementById('bsGalleryCard');
+  const gallerySection = document.getElementById('bsGallerySection');
+  const galleryPreview = document.querySelector('.bs-gallery-preview');
   let currentIndex = 0;
 
   function openLightbox(idx) {
@@ -1721,6 +1719,15 @@
   function closeLB() {
     lightbox.classList.remove('bs-show');
     document.body.style.overflow = '';
+    if (gallerySection) {
+      gallerySection.classList.remove('bs-open');
+    }
+    if (galleryPreview) {
+      galleryPreview.hidden = false;
+    }
+    if (galleryCard) {
+      galleryCard.scrollIntoView({ behavior: 'smooth' });
+    }
   }
 
   function showPrev() {
@@ -1795,8 +1802,6 @@
   }
 
   // Gallery preview card interaction
-  const galleryCard = document.getElementById('bsGalleryCard');
-  const gallerySection = document.getElementById('bsGallerySection');
   if (galleryCard && gallerySection) {
     const overlayText = galleryCard.querySelector('.bs-gallery-card__text');
     if (window.matchMedia('(hover: none)').matches) {
@@ -1804,6 +1809,9 @@
     }
     const openSection = () => {
       overlayText.textContent = 'Open';
+      if (galleryPreview) {
+        galleryPreview.hidden = true;
+      }
       gallerySection.classList.add('bs-open');
       openLightbox(0);
       gallerySection.scrollIntoView({ behavior: 'smooth' });


### PR DESCRIPTION
## Summary
- hide preview section while lightbox is open to avoid duplicate galleries
- tighten gallery padding and gaps for a compact layout on all screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a72fc8188320aa508b1d55fee2c4